### PR TITLE
Adds `/tfly town [townname] toggleflight`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
 		<dependency>
 			<groupId>com.github.TownyAdvanced</groupId>
 			<artifactId>Towny</artifactId>
-			<version>0.97.2.15</version>
+			<version>0.97.5.0</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.gmail.llmdlio</groupId>
 	<artifactId>TownyFlight</artifactId>
-	<version>1.8.0</version>
+	<version>1.8.1</version>
 	<name>TownyFlight</name>
 	<description>A flight plugin for Towny servers.</description>
 	<properties>

--- a/src/main/java/com/gmail/llmdlio/townyflight/TownyFlight.java
+++ b/src/main/java/com/gmail/llmdlio/townyflight/TownyFlight.java
@@ -12,6 +12,7 @@ import com.gmail.llmdlio.townyflight.listeners.PlayerJoinListener;
 import com.gmail.llmdlio.townyflight.listeners.PlayerLeaveTownListener;
 import com.gmail.llmdlio.townyflight.listeners.PlayerPVPListener;
 import com.gmail.llmdlio.townyflight.listeners.PlayerTeleportListener;
+import com.gmail.llmdlio.townyflight.listeners.TownStatusScreenListener;
 import com.gmail.llmdlio.townyflight.listeners.TownUnclaimListener;
 import com.palmergames.bukkit.util.Version;
 
@@ -87,6 +88,7 @@ public class TownyFlight extends JavaPlugin {
 		pm.registerEvents(new TownUnclaimListener(), this);
 		pm.registerEvents(new PlayerFallListener(), this);
 		pm.registerEvents(new PlayerTeleportListener(), this);
+		pm.registerEvents(new TownStatusScreenListener(), this);
 		if (Settings.autoEnableFlight) pm.registerEvents(new PlayerEnterTownListener(), this);
 		if (Settings.disableCombatPrevention) pm.registerEvents(new PlayerPVPListener(), this);
 	}

--- a/src/main/java/com/gmail/llmdlio/townyflight/TownyFlight.java
+++ b/src/main/java/com/gmail/llmdlio/townyflight/TownyFlight.java
@@ -16,7 +16,7 @@ import com.gmail.llmdlio.townyflight.listeners.TownUnclaimListener;
 import com.palmergames.bukkit.util.Version;
 
 public class TownyFlight extends JavaPlugin {
-	private static Version requiredTownyVersion = Version.fromString("0.97.2.15");
+	private static Version requiredTownyVersion = Version.fromString("0.97.5.0");
 	private TownyFlightConfig config = new TownyFlightConfig(this);
 	private static TownyFlight plugin;
 	private static TownyFlightAPI api;

--- a/src/main/java/com/gmail/llmdlio/townyflight/TownyFlightAPI.java
+++ b/src/main/java/com/gmail/llmdlio/townyflight/TownyFlightAPI.java
@@ -10,6 +10,7 @@ import org.bukkit.entity.Player;
 import com.gmail.goosius.siegewar.SiegeController;
 import com.gmail.llmdlio.townyflight.config.Settings;
 import com.gmail.llmdlio.townyflight.util.Message;
+import com.gmail.llmdlio.townyflight.util.MetaData;
 import com.gmail.llmdlio.townyflight.util.Permission;
 import com.gmail.llmdlio.townyflight.util.Scheduler;
 import com.palmergames.bukkit.towny.TownyAPI;
@@ -42,9 +43,11 @@ public class TownyFlightAPI {
 	 * @return true if the {@link Player} is allowed to fly.
 	 **/
 	public boolean canFly(Player player, boolean silent) {
+		Town town = TownyAPI.getInstance().getTown(player.getLocation());
 		if (player.hasPermission("townyflight.bypass") 
 			|| player.getGameMode().equals(GameMode.SPECTATOR) 
-			|| player.getGameMode().equals(GameMode.CREATIVE))
+			|| player.getGameMode().equals(GameMode.CREATIVE)
+			|| town != null && MetaData.getFreeFlightMeta(town))
 			return true;
 
 		if (!Permission.has(player, "townyflight.command.tfly", silent)) return false;

--- a/src/main/java/com/gmail/llmdlio/townyflight/TownyFlightAPI.java
+++ b/src/main/java/com/gmail/llmdlio/townyflight/TownyFlightAPI.java
@@ -151,7 +151,7 @@ public class TownyFlightAPI {
 	 */
 	public void protectFromFall(Player player) {
 		fallProtectedPlayers.add(player);
-		Scheduler.run(() -> fallProtectedPlayers.remove(player), 100);
+		Scheduler.run(() -> removeFallProtection(player), 100);
 	}
 	
 	public boolean removeFallProtection(Player player) {
@@ -168,6 +168,24 @@ public class TownyFlightAPI {
 		if (!canFly(player, silent)) removeFlight(player, false, true, "");
 	}
 
+	/**
+	 * Parse over the players online in the server and if they're in the given {@link Town},
+	 * and are not given a flight bypass of some kind, remove their flight. Called when
+	 * a town has their free flight disabled.
+	 */
+	public void takeFlightFromPlayersInTown(Town town) {
+		for (final Player player : new ArrayList<>(Bukkit.getOnlinePlayers())) {
+			if (player.hasPermission("townyflight.bypass")
+				|| !player.getAllowFlight()
+				|| TownyAPI.getInstance().isWilderness(player.getLocation())
+				|| !TownyAPI.getInstance().getTown(player.getLocation()).equals(town)
+				|| TownyFlightAPI.getInstance().canFly(player, true))
+				continue;
+
+			TownyFlightAPI.getInstance().removeFlight(player, false, true, "");
+		}	
+	}
+
 	private boolean warPrevents(Location location, Resident resident) {
 		return Settings.disableDuringWar && (townHasActiveWar(location, resident) || residentIsSieged(resident));
 	}
@@ -179,17 +197,4 @@ public class TownyFlightAPI {
 	private static boolean residentIsSieged(Resident resident) {
 		return Settings.siegeWarFound && SiegeController.hasActiveSiege(resident.getTownOrNull());
 	}
-
-	public void takeFlightFromPlayersInTown(Town town) {
-		for (final Player player : new ArrayList<>(Bukkit.getOnlinePlayers())) {
-			if (player.hasPermission("townyflight.bypass")
-				|| !player.getAllowFlight()
-				|| !TownyAPI.getInstance().getTown(player.getLocation()).equals(town)
-				|| TownyFlightAPI.getInstance().canFly(player, true))
-				continue;
-
-			TownyFlightAPI.getInstance().removeFlight(player, false, true, "");
-		}	
-	}
-	
 }

--- a/src/main/java/com/gmail/llmdlio/townyflight/TownyFlightAPI.java
+++ b/src/main/java/com/gmail/llmdlio/townyflight/TownyFlightAPI.java
@@ -1,8 +1,10 @@
 package com.gmail.llmdlio.townyflight;
 
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.bukkit.Bukkit;
 import org.bukkit.GameMode;
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
@@ -178,4 +180,16 @@ public class TownyFlightAPI {
 		return Settings.siegeWarFound && SiegeController.hasActiveSiege(resident.getTownOrNull());
 	}
 
+	public void takeFlightFromPlayersInTown(Town town) {
+		for (final Player player : new ArrayList<>(Bukkit.getOnlinePlayers())) {
+			if (player.hasPermission("townyflight.bypass")
+				|| !player.getAllowFlight()
+				|| !TownyAPI.getInstance().getTown(player.getLocation()).equals(town)
+				|| TownyFlightAPI.getInstance().canFly(player, true))
+				continue;
+
+			TownyFlightAPI.getInstance().removeFlight(player, false, true, "");
+		}	
+	}
+	
 }

--- a/src/main/java/com/gmail/llmdlio/townyflight/TownyFlightCommand.java
+++ b/src/main/java/com/gmail/llmdlio/townyflight/TownyFlightCommand.java
@@ -1,39 +1,80 @@
 package com.gmail.llmdlio.townyflight;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
 import org.bukkit.Bukkit;
 import org.bukkit.command.Command;
-import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.command.ConsoleCommandSender;
+import org.bukkit.command.TabExecutor;
 import org.bukkit.entity.Player;
 
 import com.gmail.llmdlio.townyflight.util.Message;
+import com.gmail.llmdlio.townyflight.util.MetaData;
 import com.gmail.llmdlio.townyflight.util.Permission;
+import com.palmergames.bukkit.towny.TownyAPI;
+import com.palmergames.bukkit.towny.TownyUniverse;
+import com.palmergames.bukkit.towny.object.Town;
+import com.palmergames.bukkit.towny.utils.NameUtil;
+import com.palmergames.bukkit.util.Colors;
+import com.palmergames.util.StringMgmt;
 
-public class TownyFlightCommand implements CommandExecutor {
+public class TownyFlightCommand implements TabExecutor {
 
 	private TownyFlight plugin;
+	private CommandSender sender;
+	private static final List<String> tflyTabCompletes = Arrays.asList(
+		"reload","town","help","?"
+	);
 
 	public TownyFlightCommand(TownyFlight plugin) {
 		this.plugin = plugin;
 	}
 
 	@Override
+	public List<String> onTabComplete(CommandSender sender, Command command, String alias, String[] args) {
+		if (args.length > 0) {
+			switch (args[0].toLowerCase()) {
+			case "town":
+				if (args.length == 2)
+					return getTownyStartingWith(args[1], "t");
+				if (args.length == 3)
+					return Collections.singletonList("toggleflight");
+				break;
+			default:
+				if (args.length == 1)
+					return filterByStartOrGetTownyStartingWith(tflyTabCompletes, args[0], "r");
+				else 
+					Collections.emptyList();
+			}
+		}
+		return Collections.emptyList();
+	}
+	
+	@Override
 	public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
-		
-		parseCommand(sender, args);
+		this.sender = sender;
+		parseCommand(args);
 		return true;
 	}
 	
-	private void parseCommand(CommandSender sender, String[] args) {
+	private void parseCommand(String[] args) {
 		if (sender instanceof ConsoleCommandSender) {
 			if (args.length > 0) {
-				if (args[0].equalsIgnoreCase("reload")) {
+				if (args[0].equalsIgnoreCase("?") || args[0].equalsIgnoreCase("help")) {
+					showTflyHelp();
+				} else if (args[0].equalsIgnoreCase("reload")) {
 					// Reload the plugin.
-					reloadPlugin(sender);
+					reloadPlugin();
+				} else if (args[0].equalsIgnoreCase("town")) {
+					// parse /tfly town NAME OPTION command.
+					parseTownCommand(StringMgmt.remFirstArg(args));
 				} else {
 					// It's not any other subcommand of /tfly so handle removing flight via /tfly {name}
-					toggleFlightOnOther(sender, args[0]);
+					toggleFlightOnOther(args[0]);
 				}
 			}
 			return;
@@ -42,15 +83,19 @@ public class TownyFlightCommand implements CommandExecutor {
 		if (sender instanceof Player) {
 			// We have more than just /tfly
 			if (args.length > 0) {
-				if (args[0].equalsIgnoreCase("reload")) {
-					// We have /tfly reload, test for permission node.
-					if (Permission.has(sender,"townyflight.command.tfly.reload", false))
-						reloadPlugin(sender);
+				if (args[0].equalsIgnoreCase("?") || args[0].equalsIgnoreCase("help")) {
+					showTflyHelp();
+				} else if (args[0].equalsIgnoreCase("reload") && Permission.has(sender,"townyflight.command.tfly.reload", false)) {
+					// We have /tfly reload and tested for permission node.
+					reloadPlugin();
+				} else if (args[0].equalsIgnoreCase("town") && Permission.has(sender,"townyflight.command.tfly.town", false)) {
+					// parse /tfly town NAME OPTION command.
+					parseTownCommand(StringMgmt.remFirstArg(args));
 				} else {
 					// It's not any other subcommand of /tfly so handle removing flight via /tfly {name}
 					if (Permission.has(sender, "townyflight.command.tfly.other", false))
-						toggleFlightOnOther(sender, args[0]);
-				}
+						toggleFlightOnOther(args[0]);
+				} 
 				return;
 			}
 
@@ -60,6 +105,40 @@ public class TownyFlightCommand implements CommandExecutor {
 
 			toggleFlight((Player) sender, false, false, "");
 		}
+	}
+
+	private void parseTownCommand(String[] args) {
+		if (args.length < 2) { 
+			showTflyHelp();
+			return;
+		}
+
+		Town town = TownyAPI.getInstance().getTown(args[0]);
+		if (town == null) {
+			Message.of(String.format(Message.getLangString("noTownFound"), args[0])).serious().to(sender);
+			return;
+		}
+
+		if (args[1].equalsIgnoreCase("toggleflight")) {
+			boolean active = MetaData.getFreeFlightMeta(town);
+			MetaData.setFreeFlightMeta(town, !active);
+			Message.of(String.format(Message.getLangString("townWideFlight"), Message.getLangString(!active ? "enabled" : "disabled"), town)).to(sender);
+			return;
+		}
+
+		showTflyHelp();
+	}
+	
+
+	private void showTflyHelp() {
+		if (Permission.has(sender, "townyflight.command.tfly", true))
+			Message.of(Colors.White + "/tfly - Toggle flight.").to(sender);
+		if (Permission.has(sender, "townyflight.command.tfly.reload", true))
+			Message.of(Colors.White + "/tfly reload - Reload the TownyFlight config.").to(sender);
+		if (Permission.has(sender, "townyflight.command.tfly.other", true))
+			Message.of(Colors.White + "/tfly [playername] - Toggle flight for a player.").to(sender);
+		if (Permission.has(sender, "townyflight.command.tfly.town", true))
+			Message.of(Colors.White + "/tfly town [townname] toggleflight - Toggle free flight in the given town.").to(sender);
 	}
 
 	/**
@@ -77,7 +156,7 @@ public class TownyFlightCommand implements CommandExecutor {
 			TownyFlightAPI.getInstance().addFlight(player, silent);
 	}
 
-	public void toggleFlightOnOther(CommandSender sender, String name) {
+	public void toggleFlightOnOther(String name) {
 		Player player = Bukkit.getPlayerExact(name);
 		if (player != null && player.isOnline()) {
 			if (!player.getAllowFlight()) {
@@ -91,10 +170,68 @@ public class TownyFlightCommand implements CommandExecutor {
 		}
 	}
 
-	public void reloadPlugin(CommandSender sender) {
+	public void reloadPlugin() {
 		plugin.loadSettings();
 		plugin.unregisterEvents();
 		plugin.registerEvents();
 		Message.of("TownyFlight Config & Listeners reloaded.").to(sender);
+	}
+	
+
+	/**
+	 * Returns a List<String> containing strings of resident, town, and/or nation names that match with arg.
+	 * Can check for multiple types, for example "rt" would check for residents and towns but not nations or worlds.
+	 *
+	 * @param arg the string to match with the chosen type
+	 * @param type the type of Towny object to check for, can be r(esident), t(own), n(ation), w(orld), or any combination of those to check
+	 * @return Matches for the arg with the chosen type
+	 */
+	static List<String> getTownyStartingWith(String arg, String type) {
+
+		List<String> matches = new ArrayList<>();
+		TownyUniverse townyUniverse = TownyUniverse.getInstance();
+
+		if (type.contains("r")) {
+			matches.addAll(townyUniverse.getResidentsTrie().getStringsFromKey(arg));
+		}
+
+		if (type.contains("t")) {
+			matches.addAll(townyUniverse.getTownsTrie().getStringsFromKey(arg));
+		}
+
+		if (type.contains("n")) {
+			matches.addAll(townyUniverse.getNationsTrie().getStringsFromKey(arg));
+		}
+
+		if (type.contains("w")) { // There aren't many worlds so check even if arg is empty
+			matches.addAll(NameUtil.filterByStart(NameUtil.getNames(townyUniverse.getWorldMap().values()), arg));
+		}
+
+		return matches;
+	}
+	
+	/**
+	 * Checks if arg starts with filters, if not returns matches from {@link #getTownyStartingWith(String, String)}. 
+	 * Add a "+" to the type to return both cases
+	 *
+	 * @param filters the strings to filter arg with
+	 * @param arg the string to check with filters and possibly match with Towny objects if no filters are found
+	 * @param type the type of check to use, see {@link #getTownyStartingWith(String, String)} for possible types. Add "+" to check for both filters and {@link #getTownyStartingWith(String, String)}
+	 * @return Matches for the arg filtered by filters or checked with type
+	 */
+	static List<String> filterByStartOrGetTownyStartingWith(List<String> filters, String arg, String type) {
+		List<String> filtered = NameUtil.filterByStart(filters, arg);
+		if (type.isEmpty())
+			return filtered;
+		else if (type.contains("+")) {
+			filtered.addAll(getTownyStartingWith(arg, type));
+			return filtered;
+		} else {
+			if (filtered.size() > 0) {
+				return filtered;
+			} else {
+				return getTownyStartingWith(arg, type);
+			}
+		}
 	}
 }

--- a/src/main/java/com/gmail/llmdlio/townyflight/TownyFlightCommand.java
+++ b/src/main/java/com/gmail/llmdlio/townyflight/TownyFlightCommand.java
@@ -120,9 +120,11 @@ public class TownyFlightCommand implements TabExecutor {
 		}
 
 		if (args[1].equalsIgnoreCase("toggleflight")) {
-			boolean active = MetaData.getFreeFlightMeta(town);
-			MetaData.setFreeFlightMeta(town, !active);
-			Message.of(String.format(Message.getLangString("townWideFlight"), Message.getLangString(!active ? "enabled" : "disabled"), town)).to(sender);
+			boolean futurestate = !MetaData.getFreeFlightMeta(town);
+			MetaData.setFreeFlightMeta(town, futurestate);
+			Message.of(String.format(Message.getLangString("townWideFlight"), Message.getLangString(futurestate? "enabled" : "disabled"), town)).to(sender);
+			if (!futurestate)
+				TownyFlightAPI.getInstance().takeFlightFromPlayersInTown(town);
 			return;
 		}
 

--- a/src/main/java/com/gmail/llmdlio/townyflight/config/Settings.java
+++ b/src/main/java/com/gmail/llmdlio/townyflight/config/Settings.java
@@ -52,6 +52,8 @@ public class Settings {
 		lang.put("townWideFlight", getString("townWideFlight"));
 		lang.put("disabled", getString("disabled"));
 		lang.put("enabled", getString("enabled"));
+		lang.put("statusScreenComponent", getString("statusScreenComponent"));
+		lang.put("statusScreenComponentHover", getString("statusScreenComponentHover"));
 	}
 
 	public static String getLangString(String languageString) {

--- a/src/main/java/com/gmail/llmdlio/townyflight/config/Settings.java
+++ b/src/main/java/com/gmail/llmdlio/townyflight/config/Settings.java
@@ -48,6 +48,10 @@ public class Settings {
 		lang.put("missingNode", getString("missingNode"));
 		lang.put("notDuringWar", getString("notDuringWar"));
 		lang.put("returnToAllowedArea", getString("returnToAllowedArea"));
+		lang.put("noTownFound", getString("noTownFound"));
+		lang.put("townWideFlight", getString("townWideFlight"));
+		lang.put("disabled", getString("disabled"));
+		lang.put("enabled", getString("enabled"));
 	}
 
 	public static String getLangString(String languageString) {

--- a/src/main/java/com/gmail/llmdlio/townyflight/config/TownyFlightConfig.java
+++ b/src/main/java/com/gmail/llmdlio/townyflight/config/TownyFlightConfig.java
@@ -76,11 +76,14 @@ public class TownyFlightConfig {
 		addDefault("language.townWideFlight", "Free flight has been %s in %s. ");
 		addComment("language.disabled", "# The word disabled.");
 		addDefault("language.disabled", "disabled");
-		addComment("language.enabled", "# The world enabled");
+		addComment("language.enabled", "# The world enabled.");
 		addDefault("language.enabled", "enabled");
+		addComment("language.statusScreenComponent", "# The component shown on towns' status screens when they have free flight enabled.");
+		addDefault("language.statusScreenComponent", "Free Flight");
+		addComment("language.statusScreenComponentHover", "# The hover text shown on the free flight status screen component.");
+		addDefault("language.statusScreenComponentHover", "Flight enabled for everyone within this town's borders.");
 
-		
-		addComment("options", "", "", 
+		addComment("options", "", "", "", 
 				"#################", 
 				"#    Options    #", 
 				"#################", "");

--- a/src/main/java/com/gmail/llmdlio/townyflight/config/TownyFlightConfig.java
+++ b/src/main/java/com/gmail/llmdlio/townyflight/config/TownyFlightConfig.java
@@ -70,7 +70,16 @@ public class TownyFlightConfig {
 		addDefault("language.notDuringWar", "You cannot use flight while Towny war is active. ");
 		addComment("language.returnToAllowedArea", "# Message telling a player to return to an allowed flight area.");
 		addDefault("language.returnToAllowedArea", "You have %s seconds to return to an allowed flight area. ");
+		addComment("language.noTownFound", "# Message when a town cannot be found by the name.");
+		addDefault("language.noTownFound", "TownyFlight cannot find a town by the name %s. ");
+		addComment("language.townWideFlight", "# Message when a town has free flight enabled or disabled.");
+		addDefault("language.townWideFlight", "Free flight has been %s in %s. ");
+		addComment("language.disabled", "# The word disabled.");
+		addDefault("language.disabled", "disabled");
+		addComment("language.enabled", "# The world enabled");
+		addDefault("language.enabled", "enabled");
 
+		
 		addComment("options", "", "", 
 				"#################", 
 				"#    Options    #", 

--- a/src/main/java/com/gmail/llmdlio/townyflight/listeners/TownStatusScreenListener.java
+++ b/src/main/java/com/gmail/llmdlio/townyflight/listeners/TownStatusScreenListener.java
@@ -1,0 +1,23 @@
+package com.gmail.llmdlio.townyflight.listeners;
+
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+
+import com.gmail.llmdlio.townyflight.util.Message;
+import com.gmail.llmdlio.townyflight.util.MetaData;
+import com.palmergames.adventure.text.Component;
+import com.palmergames.adventure.text.event.HoverEvent;
+import com.palmergames.bukkit.towny.event.statusscreen.TownStatusScreenEvent;
+import com.palmergames.bukkit.towny.object.Translation;
+
+public class TownStatusScreenListener implements Listener {
+	private final Component comp = Component
+			.text(Translation.of("status_format_key_value_key") + Message.getLangString("statusScreenComponent"))
+			.hoverEvent(HoverEvent.showText(Component.text(Message.getLangString("statusScreenComponentHover"))));
+
+	@EventHandler
+	public void on(TownStatusScreenEvent event) {
+		if (MetaData.getFreeFlightMeta(event.getTown()))
+			event.getStatusScreen().addComponentOf("freeflight", comp);
+	}
+}

--- a/src/main/java/com/gmail/llmdlio/townyflight/util/MetaData.java
+++ b/src/main/java/com/gmail/llmdlio/townyflight/util/MetaData.java
@@ -1,0 +1,22 @@
+package com.gmail.llmdlio.townyflight.util;
+
+import com.palmergames.bukkit.towny.object.Town;
+import com.palmergames.bukkit.towny.object.metadata.BooleanDataField;
+import com.palmergames.bukkit.towny.utils.MetaDataUtil;
+
+public class MetaData {
+
+	private static BooleanDataField freeFlight = new BooleanDataField("townyflight_freeflight");
+
+	public static boolean getFreeFlightMeta(Town town) {
+		return com.palmergames.bukkit.towny.utils.MetaDataUtil.getBoolean(town, freeFlight);
+	}
+	
+	public static void setFreeFlightMeta(Town town, boolean active) {
+		if (!town.hasMeta("townyflight_freeflight")) {
+			MetaDataUtil.addNewBooleanMeta(town, "townyflight_freeflight", active, true);
+			return;
+		} 
+		MetaDataUtil.setBoolean(town, freeFlight, active, true);
+	}
+}

--- a/src/main/java/com/gmail/llmdlio/townyflight/util/Permission.java
+++ b/src/main/java/com/gmail/llmdlio/townyflight/util/Permission.java
@@ -7,7 +7,7 @@ public class Permission {
 	public static boolean has(CommandSender sender, String node, boolean silent) {
 		if (sender.hasPermission(node))
 			return true;
-		if (!silent) Message.noPerms("townyflight.command.tfly.reload").to(sender);
+		if (!silent) Message.noPerms(node).to(sender);
 		return false;
 	}
 

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -12,9 +12,6 @@ commands:
     description: Turns flight on and off.
     aliases: [townyfly, townyflight]
     usage: "/<command>"
-  tfly reload:
-    description: Reload the TownyFlight config.
-    usage: "/<command>"
 
 permissions:
   townyflight.command.tfly:
@@ -25,6 +22,9 @@ permissions:
     default: op
   townyflight.command.tfly.other:
     description: User is able to remove flight from other players.
+    default: op
+  townyflight.command.tfly.town:
+    description: User is able to use /tfly town command.
     default: op
   townyflight.bypass:
     description: Bypass permission node for admins to not have their flight disabled while they travel the server.


### PR DESCRIPTION
An admin command which allows for a town to allow anyone to fly in it.

Bumps TownyFlight version to 1.8.1.
Bumps min. Towny version to 0.97.5.0.
Fixes missing node message only showing the reload node.
Add proper tab completion to the commands.
Add permission-aware `/tfly ?` command.
Closes #50.