### PR TITLE
Adds tempflight command.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.gmail.llmdlio</groupId>
 	<artifactId>TownyFlight</artifactId>
-	<version>1.9.0</version>
+	<version>1.10.0</version>
 	<name>TownyFlight</name>
 	<description>A flight plugin for Towny servers.</description>
 	<properties>

--- a/src/main/java/com/gmail/llmdlio/townyflight/TownyFlight.java
+++ b/src/main/java/com/gmail/llmdlio/townyflight/TownyFlight.java
@@ -3,6 +3,9 @@ package com.gmail.llmdlio.townyflight;
 import com.palmergames.bukkit.towny.scheduling.TaskScheduler;
 import com.palmergames.bukkit.towny.scheduling.impl.BukkitTaskScheduler;
 import com.palmergames.bukkit.towny.scheduling.impl.FoliaTaskScheduler;
+
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
 import org.bukkit.event.HandlerList;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.PluginManager;
@@ -21,6 +24,8 @@ import com.gmail.llmdlio.townyflight.listeners.PlayerTeleportListener;
 import com.gmail.llmdlio.townyflight.listeners.TownStatusScreenListener;
 import com.gmail.llmdlio.townyflight.listeners.TownUnclaimListener;
 import com.gmail.llmdlio.townyflight.tasks.TaskHandler;
+import com.gmail.llmdlio.townyflight.tasks.TempFlightTask;
+import com.gmail.llmdlio.townyflight.util.MetaData;
 import com.palmergames.bukkit.util.Version;
 
 public class TownyFlight extends JavaPlugin {
@@ -60,6 +65,7 @@ public class TownyFlight extends JavaPlugin {
 		getLogger().info(this.getDescription().getFullName() + " by LlmDl Enabled.");
 		
 		cycleTimerTasksOn();
+		reGrantTempFlightToOnlinePlayer();
 	}
 
 	public static TownyFlight getPlugin() {
@@ -137,6 +143,14 @@ public class TownyFlight extends JavaPlugin {
 
 	private void cycleTimerTasksOff() {
 		TaskHandler.toggleTempFlightTask(false);
+	}
+
+	private void reGrantTempFlightToOnlinePlayer() {
+		for (Player player : Bukkit.getOnlinePlayers()) {
+			long seconds = MetaData.getSeconds(player.getUniqueId());
+			if (seconds > 0L)
+				TempFlightTask.addPlayerTempFlightSeconds(player.getUniqueId(), seconds);
+		}
 	}
 
 	public TaskScheduler getScheduler() {

--- a/src/main/java/com/gmail/llmdlio/townyflight/TownyFlight.java
+++ b/src/main/java/com/gmail/llmdlio/townyflight/TownyFlight.java
@@ -20,6 +20,7 @@ import com.gmail.llmdlio.townyflight.listeners.PlayerPVPListener;
 import com.gmail.llmdlio.townyflight.listeners.PlayerTeleportListener;
 import com.gmail.llmdlio.townyflight.listeners.TownStatusScreenListener;
 import com.gmail.llmdlio.townyflight.listeners.TownUnclaimListener;
+import com.gmail.llmdlio.townyflight.tasks.TaskHandler;
 import com.palmergames.bukkit.util.Version;
 
 public class TownyFlight extends JavaPlugin {
@@ -57,6 +58,8 @@ public class TownyFlight extends JavaPlugin {
 		registerCommands();
 		getLogger().info("Towny version " + townyVersion + " found.");
 		getLogger().info(this.getDescription().getFullName() + " by LlmDl Enabled.");
+		
+		cycleTimerTasksOn();
 	}
 
 	public static TownyFlight getPlugin() {
@@ -125,6 +128,15 @@ public class TownyFlight extends JavaPlugin {
 
 	private void registerCommands() {
 		getCommand("tfly").setExecutor(new TownyFlightCommand(this));
+	}
+
+	private void cycleTimerTasksOn() {
+		cycleTimerTasksOff();
+		TaskHandler.toggleTempFlightTask(true);
+	}
+
+	private void cycleTimerTasksOff() {
+		TaskHandler.toggleTempFlightTask(false);
 	}
 
 	public TaskScheduler getScheduler() {

--- a/src/main/java/com/gmail/llmdlio/townyflight/TownyFlightAPI.java
+++ b/src/main/java/com/gmail/llmdlio/townyflight/TownyFlightAPI.java
@@ -53,11 +53,9 @@ public class TownyFlightAPI {
 	 * @return true if the {@link Player} is allowed to fly.
 	 **/
 	public boolean canFly(Player player, boolean silent) {
-		Town town = TownyAPI.getInstance().getTown(player.getLocation());
 		if (player.hasPermission("townyflight.bypass") 
 			|| player.getGameMode().equals(GameMode.SPECTATOR) 
 			|| player.getGameMode().equals(GameMode.CREATIVE)
-			|| town != null && MetaData.getFreeFlightMeta(town)
 			|| getForceAllowFlight(player))
 			return true;
 
@@ -65,11 +63,6 @@ public class TownyFlightAPI {
 
 		Resident resident = TownyUniverse.getInstance().getResident(player.getUniqueId());
 		if (resident == null) return false;
-
-		if (!resident.hasTown() && !locationTrustsResidents(town, resident)) {
-			if (!silent) Message.of("noTownMsg").to(player);
-			return false;
-		}
 
 		if (warPrevents(player.getLocation(), resident)) {
 			if (!silent) Message.of("notDuringWar").to(player);
@@ -82,11 +75,6 @@ public class TownyFlightAPI {
 		}
 		return true;
 	}
-
-	private boolean locationTrustsResidents(Town town, Resident resident) {
-		return town != null && town.hasTrustedResident(resident);
-	}
-
 
 	/**
 	 * Returns true if a player is allowed to fly at their current location. Checks
@@ -105,12 +93,19 @@ public class TownyFlightAPI {
 		if (TownyAPI.getInstance().isWilderness(location))
 			return false;
 
+		Town town = TownyAPI.getInstance().getTown(location);
+
 		if (player.hasPermission("townyflight.alltowns"))
 			return true;
 
-		Town town = TownyAPI.getInstance().getTown(location);
 		if (player.hasPermission("townyflight.trustedtowns") && town.hasTrustedResident(resident))
 			return true;
+
+		if (MetaData.getFreeFlightMeta(town))
+			return true;
+
+		if (!resident.hasTown())
+			return false;
 
 		Town residentTown = resident.getTownOrNull();
 		if (residentTown == null)

--- a/src/main/java/com/gmail/llmdlio/townyflight/TownyFlightAPI.java
+++ b/src/main/java/com/gmail/llmdlio/townyflight/TownyFlightAPI.java
@@ -15,6 +15,7 @@ import org.bukkit.entity.Player;
 import com.gmail.goosius.siegewar.SiegeController;
 import com.gmail.goosius.siegewar.enums.SiegeStatus;
 import com.gmail.llmdlio.townyflight.config.Settings;
+import com.gmail.llmdlio.townyflight.tasks.TempFlightTask;
 import com.gmail.llmdlio.townyflight.util.Message;
 import com.gmail.llmdlio.townyflight.util.MetaData;
 import com.gmail.llmdlio.townyflight.util.Permission;
@@ -60,7 +61,7 @@ public class TownyFlightAPI {
 			|| getForceAllowFlight(player))
 			return true;
 
-		if (!Permission.has(player, "townyflight.command.tfly", silent)) return false;
+		if (!hasTempFlight(player) && !Permission.has(player, "townyflight.command.tfly", silent)) return false;
 
 		Resident resident = TownyUniverse.getInstance().getResident(player.getUniqueId());
 		if (resident == null) return false;
@@ -142,6 +143,7 @@ public class TownyFlightAPI {
 				String reason = Message.getLangString("flightDeactivatedMsg");
 				if (cause == "pvp") reason = Message.getLangString("flightDeactivatedPVPMsg");
 				if (cause == "console") reason = Message.getLangString("flightDeactivatedConsoleMsg");
+				if (cause == "time") reason = Message.getLangString("flightDeactivatedTimeMsg");
 				Message.of(reason + Message.getLangString("flightOffMsg")).to(player);
 			} else {
 				Message.of("flightOffMsg").to(player);
@@ -231,6 +233,10 @@ public class TownyFlightAPI {
 	 */
 	public boolean getForceAllowFlight(Player player) {
 		return player.getPersistentDataContainer().getOrDefault(forceAllowFlight, PersistentDataType.BYTE, (byte) 0) == 1;
+	}
+
+	private boolean hasTempFlight(Player player) {
+		return TempFlightTask.getSeconds(player.getUniqueId()) > 0L;
 	}
 
 	private boolean warPrevents(Location location, Resident resident) {

--- a/src/main/java/com/gmail/llmdlio/townyflight/config/ConfigNodes.java
+++ b/src/main/java/com/gmail/llmdlio/townyflight/config/ConfigNodes.java
@@ -99,6 +99,22 @@ public enum ConfigNodes {
 			"Flight enabled for everyone within this town's borders.",
 			"",
 			"# The hover text shown on the free flight status screen component."),
+	LANG_TEMPFLIGHTGRANTEDTOPLAYER(
+			"language.tempFlightGrantedToPlayer",
+			"%s has had tempflight granted for %s.",
+			"",
+			"# The message shown to the admin/console when temp flight is given to a player."),
+	LANG_YOUHAVEBEENGIVENTEMPFLIGHT(
+			"language.youHaveReceivedTempFlight",
+			"You have been given %s of tempflight priviledges.",
+			"",
+			"# The message shown to the player when they receive temp flight."),
+	LANG_TEMPFLIGHTEXPIRED(
+			"language.yourTempFlightHasExpired",
+			"Your tempflight priviledges have expired.",
+			"",
+			"# The message shown to the player when they run out of temp flight."),
+
 	
 	OPTIONS("options", "", "",
 			"#################", 

--- a/src/main/java/com/gmail/llmdlio/townyflight/config/ConfigNodes.java
+++ b/src/main/java/com/gmail/llmdlio/townyflight/config/ConfigNodes.java
@@ -44,6 +44,11 @@ public enum ConfigNodes {
 			"Flight priviledges removed. ",
 			"",
 			"# Message shown when a player has flight taken away by console."),
+	LANG_FLIGHTDEACTIVATEDTIMEMSG(
+			"language.flightDeactivatedTimeMsg",
+			"You ran out of flight time. ",
+			"",
+			"# Message shown when a player has flight taken away because their tempflight ran out."),
 	LANG_NOPERMISSION(
 			"language.noPermission",
 			"You do not have permission for this command%s. ",

--- a/src/main/java/com/gmail/llmdlio/townyflight/config/Settings.java
+++ b/src/main/java/com/gmail/llmdlio/townyflight/config/Settings.java
@@ -44,6 +44,7 @@ public class Settings {
 		lang.put("flightDeactivatedMsg", getString("flightDeactivatedMsg"));
 		lang.put("flightDeactivatedPVPMsg", getString("flightDeactivatedPVPMsg"));
 		lang.put("flightDeactivatedConsoleMsg", getString("flightDeactivatedConsoleMsg"));
+		lang.put("flightDeactivatedTimeMsg", getString("flightDeactivatedTimeMsg"));
 		lang.put("noPermission", getString("noPermission"));
 		lang.put("missingNode", getString("missingNode"));
 		lang.put("notDuringWar", getString("notDuringWar"));

--- a/src/main/java/com/gmail/llmdlio/townyflight/config/Settings.java
+++ b/src/main/java/com/gmail/llmdlio/townyflight/config/Settings.java
@@ -55,6 +55,9 @@ public class Settings {
 		lang.put("enabled", getString("enabled"));
 		lang.put("statusScreenComponent", getString("statusScreenComponent"));
 		lang.put("statusScreenComponentHover", getString("statusScreenComponentHover"));
+		lang.put("tempFlightGrantedToPlayer", getString("tempFlightGrantedToPlayer"));
+		lang.put("youHaveReceivedTempFlight", getString("youHaveReceivedTempFlight"));
+		lang.put("yourTempFlightHasExpired", getString("yourTempFlightHasExpired"));
 	}
 
 	public static String getLangString(String languageString) {

--- a/src/main/java/com/gmail/llmdlio/townyflight/integrations/TownyFlightPlaceholderExpansion.java
+++ b/src/main/java/com/gmail/llmdlio/townyflight/integrations/TownyFlightPlaceholderExpansion.java
@@ -112,6 +112,9 @@ public class TownyFlightPlaceholderExpansion extends PlaceholderExpansion {
 			return String.valueOf(TownyFlightAPI.canFlyAccordingToCache(player));
 		case "temp_flight_seconds_remaining": // %townyflight_temp_flight_seconds_remaining%
 			return TimeMgmt.getFormattedTimeValue(TempFlightTask.getSeconds(offlineplayer.getUniqueId()) * 1000L);
+		case "temp_flight_seconds_remaining_raw": // %townyflight_temp_flight_seconds_remaining_raw%
+			return String.valueOf(TempFlightTask.getSeconds(offlineplayer.getUniqueId()));
+
 		default:
 			return "";
 		}

--- a/src/main/java/com/gmail/llmdlio/townyflight/integrations/TownyFlightPlaceholderExpansion.java
+++ b/src/main/java/com/gmail/llmdlio/townyflight/integrations/TownyFlightPlaceholderExpansion.java
@@ -5,6 +5,8 @@ import org.bukkit.entity.Player;
 
 import com.gmail.llmdlio.townyflight.TownyFlight;
 import com.gmail.llmdlio.townyflight.TownyFlightAPI;
+import com.gmail.llmdlio.townyflight.tasks.TempFlightTask;
+import com.palmergames.util.TimeMgmt;
 
 import me.clip.placeholderapi.expansion.PlaceholderExpansion;
 import net.md_5.bungee.api.ChatColor;
@@ -108,6 +110,8 @@ public class TownyFlightPlaceholderExpansion extends PlaceholderExpansion {
 		switch (identifier) {
 		case "can_player_fly": // %townyflight_can_player_fly%
 			return String.valueOf(TownyFlightAPI.canFlyAccordingToCache(player));
+		case "temp_flight_seconds_remaining": // %townyflight_temp_flight_seconds_remaining%
+			return TimeMgmt.getFormattedTimeValue(TempFlightTask.getSeconds(offlineplayer.getUniqueId()) * 1000L);
 		default:
 			return "";
 		}

--- a/src/main/java/com/gmail/llmdlio/townyflight/listeners/PlayerJoinListener.java
+++ b/src/main/java/com/gmail/llmdlio/townyflight/listeners/PlayerJoinListener.java
@@ -9,6 +9,8 @@ import org.bukkit.event.player.PlayerJoinEvent;
 
 import com.gmail.llmdlio.townyflight.TownyFlightAPI;
 import com.gmail.llmdlio.townyflight.config.Settings;
+import com.gmail.llmdlio.townyflight.tasks.TempFlightTask;
+import com.gmail.llmdlio.townyflight.util.MetaData;
 
 public class PlayerJoinListener implements Listener {
 	private final TownyFlight plugin;
@@ -26,6 +28,10 @@ public class PlayerJoinListener implements Listener {
 		final Player player = event.getPlayer();
 
 		plugin.getScheduler().runLater(player, () -> {
+			long seconds = MetaData.getSeconds(player.getUniqueId());
+			if (seconds > 0L)
+				TempFlightTask.addPlayerTempFlightSeconds(player.getUniqueId(), seconds);
+
 			boolean canFly = TownyFlightAPI.getInstance().canFly(player, true);
 			boolean isFlying = player.isFlying();
 			if (isFlying && canFly)

--- a/src/main/java/com/gmail/llmdlio/townyflight/listeners/PlayerLogOutListener.java
+++ b/src/main/java/com/gmail/llmdlio/townyflight/listeners/PlayerLogOutListener.java
@@ -5,6 +5,7 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerQuitEvent;
 
 import com.gmail.llmdlio.townyflight.TownyFlightAPI;
+import com.gmail.llmdlio.townyflight.tasks.TempFlightTask;
 
 public class PlayerLogOutListener implements Listener {
 
@@ -12,5 +13,6 @@ public class PlayerLogOutListener implements Listener {
 	public void onPlayerQuit(PlayerQuitEvent event) {
 		TownyFlightAPI.getInstance().testForFlight(event.getPlayer(), true);
 		TownyFlightAPI.removeCachedPlayer(event.getPlayer());
+		TempFlightTask.logOutPlayerWithRemainingTempFlight(event.getPlayer());
 	}
 }

--- a/src/main/java/com/gmail/llmdlio/townyflight/tasks/TaskHandler.java
+++ b/src/main/java/com/gmail/llmdlio/townyflight/tasks/TaskHandler.java
@@ -1,0 +1,26 @@
+package com.gmail.llmdlio.townyflight.tasks;
+
+import com.gmail.llmdlio.townyflight.TownyFlight;
+import com.palmergames.bukkit.towny.scheduling.ScheduledTask;
+
+public class TaskHandler {
+
+	private static ScheduledTask tempFlightTask = null;
+	private static Runnable tempFlightRunnable = null;
+
+	public static void toggleTempFlightTask(boolean on) {
+		if (on && !isTempFlightTaskRunning()) {
+			if (tempFlightRunnable == null)
+				tempFlightRunnable = new TempFlightTask();
+			tempFlightTask = TownyFlight.getPlugin().getScheduler().runRepeating(tempFlightRunnable, 60L, 20L);
+		} else if (!on && isTempFlightTaskRunning()) {
+			tempFlightTask.cancel();
+			tempFlightTask = null;
+			tempFlightRunnable = null;
+		}
+	}
+
+	public static boolean isTempFlightTaskRunning() {
+		return tempFlightTask != null && !tempFlightTask.isCancelled();
+	}
+}

--- a/src/main/java/com/gmail/llmdlio/townyflight/tasks/TempFlightTask.java
+++ b/src/main/java/com/gmail/llmdlio/townyflight/tasks/TempFlightTask.java
@@ -1,0 +1,98 @@
+package com.gmail.llmdlio.townyflight.tasks;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+
+import com.gmail.llmdlio.townyflight.TownyFlightAPI;
+import com.gmail.llmdlio.townyflight.util.MetaData;
+import com.palmergames.bukkit.towny.TownyAPI;
+import com.palmergames.bukkit.towny.object.Resident;
+
+public class TempFlightTask implements Runnable {
+
+	private static Map<UUID, Long> playerUUIDSecondsMap = new ConcurrentHashMap<>();
+	private int cycles = 0;
+
+	@Override
+	public void run() {
+		cycles++;
+		removeFlightFromPlayersWithNoTimeLeft();
+
+		Set<UUID> uuidsToDecrement = new HashSet<>();
+		for (Player player : new ArrayList<>(Bukkit.getOnlinePlayers())) {
+			if (!player.getAllowFlight() || !player.isFlying())
+				continue;
+			UUID uuid = player.getUniqueId();
+			if (!playerUUIDSecondsMap.containsKey(uuid))
+				continue;
+			uuidsToDecrement.add(uuid);
+		}
+
+		uuidsToDecrement.forEach(uuid -> decrementSeconds(uuid));
+		if (cycles % 10 == 0)
+			cycles = 0;
+	}
+
+	private void decrementSeconds(UUID uuid) {
+		long seconds = playerUUIDSecondsMap.get(uuid);
+		playerUUIDSecondsMap.put(uuid, --seconds);
+		// Save players every 10 seconds;
+		if (cycles % 10 == 0) {
+			Resident resident = TownyAPI.getInstance().getResident(uuid);
+			if (resident == null)
+				return;
+			MetaData.setSeconds(resident, seconds, true);
+		}
+	}
+
+	private void removeFlightFromPlayersWithNoTimeLeft() {
+		Set<UUID> uuidsToRemove = playerUUIDSecondsMap.entrySet().stream()
+				.filter(e -> e.getValue() <= 0)
+				.map(e -> e.getKey())
+				.collect(Collectors.toSet());
+		uuidsToRemove.forEach(uuid -> removeFlight(uuid));
+	}
+
+	private void removeFlight(UUID uuid) {
+		playerUUIDSecondsMap.remove(uuid);
+		Player player = Bukkit.getPlayer(uuid);
+		if (player != null && player.isOnline())
+			TownyFlightAPI.getInstance().removeFlight(player, false, true, "time");
+		MetaData.removeFlightMeta(uuid);
+	}
+
+	public static long getSeconds(UUID uuid) {
+		return playerUUIDSecondsMap.containsKey(uuid) ? playerUUIDSecondsMap.get(uuid) : 0L;
+	}
+
+	public static void addPlayerTempFlightSeconds(UUID uuid, long seconds) {
+		long existingSeconds = playerUUIDSecondsMap.containsKey(uuid) ? playerUUIDSecondsMap.get(uuid) : 0L;  
+		playerUUIDSecondsMap.put(uuid, existingSeconds + seconds);
+	}
+
+	public static void removeAllPlayerTempFlightSeconds(Player player) {
+		UUID uuid = player.getUniqueId();
+		playerUUIDSecondsMap.put(uuid, 0L);
+	}
+
+	public static void logOutPlayerWithRemainingTempFlight(Player player) {
+		if (!playerUUIDSecondsMap.containsKey(player.getUniqueId()))
+			return;
+		long seconds = playerUUIDSecondsMap.get(player.getUniqueId());
+		if (seconds <= 0L)
+			return;
+		Resident resident = TownyAPI.getInstance().getResident(player);
+		if (resident == null)
+			return;
+		MetaData.setSeconds(resident, seconds, true);
+		playerUUIDSecondsMap.remove(player.getUniqueId());
+	}
+}

--- a/src/main/java/com/gmail/llmdlio/townyflight/tasks/TempFlightTask.java
+++ b/src/main/java/com/gmail/llmdlio/townyflight/tasks/TempFlightTask.java
@@ -12,6 +12,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 
 import com.gmail.llmdlio.townyflight.TownyFlightAPI;
+import com.gmail.llmdlio.townyflight.util.Message;
 import com.gmail.llmdlio.townyflight.util.MetaData;
 import com.palmergames.bukkit.towny.TownyAPI;
 import com.palmergames.bukkit.towny.object.Resident;
@@ -24,6 +25,7 @@ public class TempFlightTask implements Runnable {
 	@Override
 	public void run() {
 		cycles++;
+
 		removeFlightFromPlayersWithNoTimeLeft();
 
 		Set<UUID> uuidsToDecrement = new HashSet<>();
@@ -58,7 +60,12 @@ public class TempFlightTask implements Runnable {
 				.filter(e -> e.getValue() <= 0)
 				.map(e -> e.getKey())
 				.collect(Collectors.toSet());
-		uuidsToRemove.forEach(uuid -> removeFlight(uuid));
+		uuidsToRemove.forEach(uuid -> {
+			removeFlight(uuid);
+			Player player = Bukkit.getPlayer(uuid);
+			if (player != null && player.isOnline())
+				Message.of(String.format(Message.getLangString("yourTempFlightHasExpired"))).to(player);
+		});
 	}
 
 	private void removeFlight(UUID uuid) {
@@ -74,12 +81,11 @@ public class TempFlightTask implements Runnable {
 	}
 
 	public static void addPlayerTempFlightSeconds(UUID uuid, long seconds) {
-		long existingSeconds = playerUUIDSecondsMap.containsKey(uuid) ? playerUUIDSecondsMap.get(uuid) : 0L;  
+		long existingSeconds = playerUUIDSecondsMap.containsKey(uuid) ? playerUUIDSecondsMap.get(uuid) : 0L;
 		playerUUIDSecondsMap.put(uuid, existingSeconds + seconds);
 	}
 
-	public static void removeAllPlayerTempFlightSeconds(Player player) {
-		UUID uuid = player.getUniqueId();
+	public static void removeAllPlayerTempFlightSeconds(UUID uuid) {
 		playerUUIDSecondsMap.put(uuid, 0L);
 	}
 

--- a/src/main/java/com/gmail/llmdlio/townyflight/util/MetaData.java
+++ b/src/main/java/com/gmail/llmdlio/townyflight/util/MetaData.java
@@ -1,7 +1,12 @@
 package com.gmail.llmdlio.townyflight.util;
 
+import java.util.UUID;
+
+import com.palmergames.bukkit.towny.TownyAPI;
+import com.palmergames.bukkit.towny.object.Resident;
 import com.palmergames.bukkit.towny.object.Town;
 import com.palmergames.bukkit.towny.object.metadata.BooleanDataField;
+import com.palmergames.bukkit.towny.object.metadata.LongDataField;
 import com.palmergames.bukkit.towny.utils.MetaDataUtil;
 
 public class MetaData {
@@ -18,5 +23,46 @@ public class MetaData {
 			return;
 		} 
 		MetaDataUtil.setBoolean(town, freeFlight, active, true);
+	}
+
+	private static LongDataField tempFlightSeconds = new LongDataField("townyflight_tempflightseconds");
+
+
+	public static void addTempFlight(UUID uuid, long seconds) {
+		Resident resident = TownyAPI.getInstance().getResident(uuid);
+		if (resident == null)
+			return;
+		addTempFlight(resident, seconds);
+	}
+
+	public static void addTempFlight(Resident resident, long seconds) {
+		long existingSeconds = MetaDataUtil.getLong(resident, tempFlightSeconds);
+		MetaDataUtil.setLong(resident, tempFlightSeconds, existingSeconds + seconds, true);
+	}
+
+	public static long getSeconds(UUID uuid) {
+		Resident resident = TownyAPI.getInstance().getResident(uuid);
+		if (resident == null)
+			return 0L;
+		return getSeconds(resident);
+	}
+	
+	private static long getSeconds(Resident resident) {
+		return MetaDataUtil.getLong(resident, tempFlightSeconds);
+	}
+
+	public static void setSeconds(Resident resident, long seconds, boolean save) {
+		MetaDataUtil.setLong(resident, tempFlightSeconds, seconds, save);
+	}
+
+	public static void removeFlightMeta(UUID uuid) {
+		Resident resident = TownyAPI.getInstance().getResident(uuid);
+		if (resident == null)
+			return;
+		removeFlightMeta(resident);
+	}
+
+	public static void removeFlightMeta(Resident resident) {
+		resident.removeMetaData(tempFlightSeconds);
 	}
 }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -21,6 +21,9 @@ permissions:
   townyflight.command.tfly.reload:
     description: User is able to reload the config.
     default: op
+  townyflight.command.tfly.tempflight:
+    description: User is able to grant tempflight to players.
+    default: op
   townyflight.command.tfly.other:
     description: User is able to remove flight from other players.
     default: op


### PR DESCRIPTION
Closes https://github.com/TownyAdvanced/Towny/issues/7252

TODO:

- [x] add feedback messages,
- [x] test Placeholder,
- [x] test saving every 10 cycles,
- [x] test logging out storing remaining flight, logging in restoring it.

```
  - New Feature: tempflight
    - tempflight is given to players who will be able to fly for a specific amount of time, without having the `townyflight.command.tfly` permission node that is normally required for flight.
    - Temporarily flying players will use up their flight seconds while they are flying and not while they are properly grounded. 
    - Temporarily flying players will only be able to use their flight powers in areas that TownyFlight would normally allow a player to fly in.

  - New PAPI Placeholders:
     - `%townyflight_temp_flight_seconds_remaining%` - Shows a formatted flight time remaining, ie: 30 seconds, or 5 minutes 2 seconds.
     - %townyflight_temp_flight_seconds_remaining_raw% - Shows the number of seconds of flight time remaining with no formatting, ie: 30, or 302.

  - New commands:
    - /t fly tempflight [playername] 1000 - Gives a number of seconds of flight to a player.
    - /t fly tempflight [playername] [30s | 30m | 1h |  2d] - Gives an amount of seconds of flight to a player, in an easier to input format.
    - /t fly tempflight [playername] [remove] - Removes temp flight seconds from a player.

  - New permission node:
    - townyflight.command.tfly.tempflight: User is able to grant tempflight to players.
      - default: op
```