### PR TITLE
Add tempflight allowed areas to config.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.gmail.llmdlio</groupId>
 	<artifactId>TownyFlight</artifactId>
-	<version>1.11.0</version>
+	<version>1.12.0</version>
 	<name>TownyFlight</name>
 	<description>A flight plugin for Towny servers.</description>
 	<properties>

--- a/src/main/java/com/gmail/llmdlio/townyflight/config/ConfigNodes.java
+++ b/src/main/java/com/gmail/llmdlio/townyflight/config/ConfigNodes.java
@@ -141,6 +141,11 @@ public enum ConfigNodes {
 			"false",
 			"",
 			"# If set to false, TownyFlight will not prevent combat of flying people."),
+	OPTIONS_TEMPFLIGHT_ALLOWED_AREAS(
+			"options.tempflight_allowed_areas",
+			"owntown,nationtowns",
+			"",
+			"# The list of areas which allow tempflight, allowed words: owntown, nationtowns, alliedtowns, alltowns, trustedtowns, wilderness"),
 	OPTIONS_SHOW_PERMISSION(
 			"options.show_Permission_After_No_Permission_Message", 
 			"true",

--- a/src/main/java/com/gmail/llmdlio/townyflight/config/Settings.java
+++ b/src/main/java/com/gmail/llmdlio/townyflight/config/Settings.java
@@ -1,8 +1,8 @@
 package com.gmail.llmdlio.townyflight.config;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
-
 import org.bukkit.ChatColor;
 import org.bukkit.configuration.ConfigurationSection;
 
@@ -16,6 +16,7 @@ public class Settings {
 	public static Boolean showPermissionInMessage;
 	public static Boolean siegeWarFound;
 	public static int flightDisableTimer;
+	public static List<String> allowedTempFlightAreas;
 	private static Map<String, String> lang = new HashMap<String,String>();
 
 	public static boolean loadSettings(TownyFlightConfig _config) {
@@ -32,6 +33,7 @@ public class Settings {
 		disableCombatPrevention = Boolean.valueOf(getOption("disable_Combat_Prevention"));
 		showPermissionInMessage = Boolean.valueOf(getOption("show_Permission_After_No_Permission_Message"));
 		flightDisableTimer = Integer.valueOf(getOption("flight_Disable_Timer"));
+		allowedTempFlightAreas = allowedTempFlightAreas();
 	}
 
 	public static void loadStrings() {
@@ -75,11 +77,20 @@ public class Settings {
 	private static String getString(String string) {
 		return colour(getConfig("language").getString(string));
 	}
-	
+
 	private static ConfigurationSection getConfig(String path) {
 		return config.getConfig().getConfigurationSection(path);
 	}
+
 	private static String colour(String string) {
 		return ChatColor.translateAlternateColorCodes('&', string);
+	}
+
+	public static List<String> allowedTempFlightAreas() {
+		return config.getStrArr(ConfigNodes.OPTIONS_TEMPFLIGHT_ALLOWED_AREAS);
+	}
+	
+	public static boolean isAllowedTempFlightArea(String area) {
+		return allowedTempFlightAreas.contains(area);
 	}
 }

--- a/src/main/java/com/gmail/llmdlio/townyflight/config/TownyFlightConfig.java
+++ b/src/main/java/com/gmail/llmdlio/townyflight/config/TownyFlightConfig.java
@@ -3,6 +3,9 @@ package com.gmail.llmdlio.townyflight.config;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import com.gmail.llmdlio.townyflight.TownyFlight;
 import com.palmergames.bukkit.config.CommentedConfiguration;
@@ -78,5 +81,23 @@ public class TownyFlightConfig {
 		if (value == null)
 			value = "";
 		newConfig.set(root, value.toString());
+	}
+
+	public static String getString(String root, String def) {
+
+		String data = config.getString(root.toLowerCase(), def);
+		if (data == null) {
+			TownyFlight.getPlugin().getLogger().warning(root.toLowerCase() + " from config.yml");
+			return "";
+		}
+		return data;
+	}
+
+	public static String getString(ConfigNodes node) {
+		return config.getString(node.getRoot().toLowerCase(), node.getDefault());
+	}
+
+	public List<String> getStrArr(ConfigNodes node) {
+		return Arrays.stream(getString(node).split(",")).collect(Collectors.toList());
 	}
 }


### PR DESCRIPTION
Closes #81

Used because using permission nodes would likely require a whole new set of nodes.