### PR TITLE
Added toggling flight publicly within your town

### DIFF
--- a/src/main/java/com/gmail/llmdlio/townyflight/TownyFlightCommand.java
+++ b/src/main/java/com/gmail/llmdlio/townyflight/TownyFlightCommand.java
@@ -58,20 +58,20 @@ public class TownyFlightCommand implements TabExecutor {
 			default:
 				if (args.length == 1)
 					return filterByStartOrGetTownyStartingWith(tflyTabCompletes, args[0], "r");
-				else 
+				else
 					Collections.emptyList();
 			}
 		}
 		return Collections.emptyList();
 	}
-	
+
 	@Override
 	public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
 		this.sender = sender;
 		parseCommand(args);
 		return true;
 	}
-	
+
 	private void parseCommand(String[] args) {
 		if (sender instanceof ConsoleCommandSender) {
 			if (args.length > 0) {
@@ -112,7 +112,7 @@ public class TownyFlightCommand implements TabExecutor {
 					// It's not any other subcommand of /tfly so handle removing flight via /tfly {name}
 					if (Permission.has(sender, "townyflight.command.tfly.other", false))
 						toggleFlightOnOther(args[0]);
-				} 
+				}
 				return;
 			}
 
@@ -185,29 +185,57 @@ public class TownyFlightCommand implements TabExecutor {
 	}
 
 	private void parseTownCommand(String[] args) {
-		if (args.length < 2) { 
+		if (args.length < 1) {
 			showTflyHelp();
 			return;
 		}
 
-		Town town = TownyAPI.getInstance().getTown(args[0]);
-		if (town == null) {
-			Message.of(String.format(Message.getLangString("noTownFound"), args[0])).serious().to(sender);
-			return;
-		}
+		if(args[0].equalsIgnoreCase("toggleflight") && sender instanceof Player) {
+			Resident resident = TownyAPI.getInstance().getResident((Player)sender);
+			if (resident == null) {
+				Message.of(String.format(Message.getLangString("notMayorMsg"))).to(sender);
+				return;
+			}
 
-		if (args[1].equalsIgnoreCase("toggleflight")) {
+			if (!resident.isMayor()) {
+				Message.of(String.format(Message.getLangString("notMayorMsg"))).to(sender);
+				return;
+			}
+
+			Town town = resident.getTownOrNull();
+
 			boolean futurestate = !MetaData.getFreeFlightMeta(town);
 			MetaData.setFreeFlightMeta(town, futurestate);
-			Message.of(String.format(Message.getLangString("townWideFlight"), Message.getLangString(futurestate? "enabled" : "disabled"), town)).to(sender);
+			Message.of(String.format(Message.getLangString("townWideFlight"), Message.getLangString(futurestate ? "enabled" : "disabled"), town)).to(sender);
 			if (!futurestate)
 				TownyFlightAPI.getInstance().takeFlightFromPlayersInTown(town);
 			return;
+		} else if(Permission.has(sender,"townyflight.command.tfly.town.other", false)){
+			if(args.length < 2) {
+				showTflyHelp();
+				return;
+			}
+
+			Town town = TownyAPI.getInstance().getTown(args[0]);
+			if (town == null) {
+				Message.of(String.format(Message.getLangString("noTownFound"), args[0])).serious().to(sender);
+				return;
+			}
+
+			if (args[1].equalsIgnoreCase("toggleflight")) {
+				boolean futurestate = !MetaData.getFreeFlightMeta(town);
+				MetaData.setFreeFlightMeta(town, futurestate);
+				Message.of(String.format(Message.getLangString("townWideFlight"), Message.getLangString(futurestate ? "enabled" : "disabled"), town)).to(sender);
+				if (!futurestate)
+					TownyFlightAPI.getInstance().takeFlightFromPlayersInTown(town);
+				return;
+			}
+
 		}
 
 		showTflyHelp();
 	}
-	
+
 
 	private void showTflyHelp() {
 		if (Permission.has(sender, "townyflight.command.tfly", true))
@@ -224,12 +252,14 @@ public class TownyFlightCommand implements TabExecutor {
 		if (Permission.has(sender, "townyflight.command.tfly.other", true))
 			Message.of(Colors.White + "/tfly [playername] - Toggle flight for a player.").to(sender);
 		if (Permission.has(sender, "townyflight.command.tfly.town", true))
+			Message.of(Colors.White + "/tfly town toggleflight - Toggle free flight in your town.").to(sender);
+		if (Permission.has(sender, "townyflight.command.tfly.town.other", true))
 			Message.of(Colors.White + "/tfly town [townname] toggleflight - Toggle free flight in the given town.").to(sender);
 	}
 
 	/**
 	 * If flight is on, turn it off and vice versa
-	 * 
+	 *
 	 * @param player {@link Player} toggling flight.
 	 * @param silent true will mean no message is shown to the {@link Player}.
 	 * @param forced true if this is a forced deactivation or not.
@@ -262,7 +292,7 @@ public class TownyFlightCommand implements TabExecutor {
 		plugin.registerEvents();
 		Message.of("TownyFlight Config & Listeners reloaded.").to(sender);
 	}
-	
+
 
 	/**
 	 * Returns a List<String> containing strings of resident, town, and/or nation names that match with arg.
@@ -295,9 +325,9 @@ public class TownyFlightCommand implements TabExecutor {
 
 		return matches;
 	}
-	
+
 	/**
-	 * Checks if arg starts with filters, if not returns matches from {@link #getTownyStartingWith(String, String)}. 
+	 * Checks if arg starts with filters, if not returns matches from {@link #getTownyStartingWith(String, String)}.
 	 * Add a "+" to the type to return both cases
 	 *
 	 * @param filters the strings to filter arg with

--- a/src/main/java/com/gmail/llmdlio/townyflight/config/ConfigNodes.java
+++ b/src/main/java/com/gmail/llmdlio/townyflight/config/ConfigNodes.java
@@ -19,6 +19,11 @@ public enum ConfigNodes {
 			"Flight De-Activated. ",
 			"",
 			"# Message shown when flight de-activated."),
+	LANG_NOTMAYOR(
+			"language.notMayorMsg",
+			"You are not the mayor of a town. ",
+			"",
+			"# Message shown when player lacks mayor status somewhere."),
 	LANG_NOTOWN(
 			"language.noTownMsg",
 			"Flight cannot be activated, you don't belong to a town. ",
@@ -60,7 +65,7 @@ public enum ConfigNodes {
 			"",
 			"# Message attached to noPermission when options.show_Permission_After_No_Permission_Message is true"),
 	LANG_NOTDURINGWAR(
-			"language.notDuringWar", 
+			"language.notDuringWar",
 			"You cannot use flight while Towny war is active. ",
 			"",
 			"# Message shown when war is active and flight is disallowed."),
@@ -80,7 +85,7 @@ public enum ConfigNodes {
 			"",
 			"# Message when a town has free flight enabled or disabled."),
 	LANG_DISABLED(
-			"language.disabled", 
+			"language.disabled",
 			"disabled",
 			"",
 			"# The word disabled."),
@@ -90,7 +95,7 @@ public enum ConfigNodes {
 			"",
 			"# The world enabled."),
 	LANG_STATUSSCREENCOMP(
-			"language.statusScreenComponent", 
+			"language.statusScreenComponent",
 			"Free Flight",
 			"",
 			"# The component shown on towns' status screens when they have free flight enabled."),
@@ -115,10 +120,10 @@ public enum ConfigNodes {
 			"",
 			"# The message shown to the player when they run out of temp flight."),
 
-	
+
 	OPTIONS("options", "", "",
-			"#################", 
-			"#    Options    #", 
+			"#################",
+			"#    Options    #",
 			"#################"),
 	OPTIONS_AUTO_ENABLE_FLIGHT(
 			"options.auto_Enable_Flight",
@@ -127,17 +132,17 @@ public enum ConfigNodes {
 			"# If set to true, players entering their town will have flight auto-enabled.",
 			"# When set to true, the plugin will use slightly more resources due to the EnterTown listener."),
 	OPTIONS_AUTO_ENABLE_SILENT(
-			"options.auto_Enable_Silent", 
+			"options.auto_Enable_Silent",
 			"false",
 			"",
 			"# If set to true, players entering their town will have flight auto-enabled without being notified in chat."),
 	OPTIONS_DISABLE_DURING_WARTIME(
-			"options.disable_During_Wartime", 
+			"options.disable_During_Wartime",
 			"true",
 			"",
 			"# If set to false, players can still fly in their town while war is active."),
 	OPTIONS_DISABLE_COMBAT_PREVENT(
-			"options.disable_Combat_Prevention", 
+			"options.disable_Combat_Prevention",
 			"false",
 			"",
 			"# If set to false, TownyFlight will not prevent combat of flying people."),
@@ -147,7 +152,7 @@ public enum ConfigNodes {
 			"",
 			"# The list of areas which allow tempflight, allowed words: owntown, nationtowns, alliedtowns, alltowns, trustedtowns, wilderness"),
 	OPTIONS_SHOW_PERMISSION(
-			"options.show_Permission_After_No_Permission_Message", 
+			"options.show_Permission_After_No_Permission_Message",
 			"true",
 			"",
 			"# If set to false, the language.noPermission message will not display the permission node."),

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -30,6 +30,9 @@ permissions:
   townyflight.command.tfly.town:
     description: User is able to use /tfly town command.
     default: op
+  townyflight.command.tfly.town.other:
+    description: User is able to use /tfly town [town] command on other towns.
+    default: op
   townyflight.bypass:
     description: Bypass permission node for admins to not have their flight disabled while they travel the server.
     default: op


### PR DESCRIPTION
Made it so mayors of towns can toggle public flight within their town with /tfly town toggleflight
added a new permission so people with
  townyflight.command.tfly.town.other
can toggle the flight of any town while just townyflight.command.tfly.town can only toggle their towns