### PR TITLE
Fix temp flight seconds being deducted from admins with permission node and in non-towny worlds.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.gmail.llmdlio</groupId>
 	<artifactId>TownyFlight</artifactId>
-	<version>1.14.0</version>
+	<version>1.14.1</version>
 	<name>TownyFlight</name>
 	<description>A flight plugin for Towny servers.</description>
 	<properties>

--- a/src/main/java/com/gmail/llmdlio/townyflight/config/Settings.java
+++ b/src/main/java/com/gmail/llmdlio/townyflight/config/Settings.java
@@ -3,8 +3,9 @@ package com.gmail.llmdlio.townyflight.config;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.bukkit.ChatColor;
 import org.bukkit.configuration.ConfigurationSection;
+
+import com.palmergames.bukkit.util.Colors;
 
 public class Settings {
 
@@ -83,7 +84,7 @@ public class Settings {
 	}
 
 	private static String colour(String string) {
-		return ChatColor.translateAlternateColorCodes('&', string);
+		return Colors.translateColorCodes(string);
 	}
 
 	public static List<String> allowedTempFlightAreas() {

--- a/src/main/java/com/gmail/llmdlio/townyflight/tasks/TempFlightTask.java
+++ b/src/main/java/com/gmail/llmdlio/townyflight/tasks/TempFlightTask.java
@@ -14,6 +14,7 @@ import org.bukkit.entity.Player;
 import com.gmail.llmdlio.townyflight.TownyFlightAPI;
 import com.gmail.llmdlio.townyflight.util.Message;
 import com.gmail.llmdlio.townyflight.util.MetaData;
+import com.gmail.llmdlio.townyflight.util.Permission;
 import com.palmergames.bukkit.towny.TownyAPI;
 import com.palmergames.bukkit.towny.object.Resident;
 
@@ -30,6 +31,10 @@ public class TempFlightTask implements Runnable {
 
 		Set<UUID> uuidsToDecrement = new HashSet<>();
 		for (Player player : new ArrayList<>(Bukkit.getOnlinePlayers())) {
+			if (!TownyAPI.getInstance().isTownyWorld(player.getWorld()))
+				continue;
+			if (Permission.has(player, "townyflight.bypass", true))
+				continue;
 			if (!player.getAllowFlight() || !player.isFlying())
 				continue;
 			UUID uuid = player.getUniqueId();


### PR DESCRIPTION
Closes #96

Being in a non-towny world, or having `townyflight.bypass` will cause tempflight seconds to not be deducted.