### PR TITLE
Add the ability to choose where messages go to.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,14 +4,14 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.gmail.llmdlio</groupId>
 	<artifactId>TownyFlight</artifactId>
-	<version>1.14.1</version>
+	<version>1.14.2</version>
 	<name>TownyFlight</name>
 	<description>A flight plugin for Towny servers.</description>
 	<properties>
 		<java.version>21</java.version>
 		<project.bukkitAPIVersion>1.19</project.bukkitAPIVersion>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<towny.version>0.101.2.5</towny.version>
+		<towny.version>0.102.0.0</towny.version>
 	</properties>
 	<build>
 		<defaultGoal>clean package</defaultGoal>

--- a/src/main/java/com/gmail/llmdlio/townyflight/TownyFlight.java
+++ b/src/main/java/com/gmail/llmdlio/townyflight/TownyFlight.java
@@ -32,7 +32,7 @@ import com.gmail.llmdlio.townyflight.util.MetaData;
 import com.palmergames.bukkit.util.Version;
 
 public class TownyFlight extends JavaPlugin {
-	private static final Version requiredTownyVersion = Version.fromString("0.101.2.5");
+	private static final Version requiredTownyVersion = Version.fromString("0.102.0.0");
 	private TownyFlightConfig config = new TownyFlightConfig(this);
 	private static TownyFlight plugin;
 	private static TownyFlightAPI api;

--- a/src/main/java/com/gmail/llmdlio/townyflight/config/ConfigNodes.java
+++ b/src/main/java/com/gmail/llmdlio/townyflight/config/ConfigNodes.java
@@ -151,6 +151,16 @@ public enum ConfigNodes {
 			"owntown,nationtowns",
 			"",
 			"# The list of areas which allow tempflight, allowed words: owntown, nationtowns, alliedtowns, alltowns, trustedtowns, wilderness"),
+	OPTIONS_MESSAGES_DESTINATION(
+			"options.messages_appear_in",
+			"chat",
+			"",
+			"# Where messages will appear, options are: chat, actionbar, title"),
+	OPTIONS_RETURN_TO_TOWN_MESSAGE_DESTINATION(
+			"options.returnToAllowedArea_appears_in_title_message_override",
+			"false",
+			"",
+			"# When false, the returnToAllowedArea message will appear in the default message location, when it is true it will always appear as a title message."),
 	OPTIONS_SHOW_PERMISSION(
 			"options.show_Permission_After_No_Permission_Message", 
 			"true",

--- a/src/main/java/com/gmail/llmdlio/townyflight/config/Settings.java
+++ b/src/main/java/com/gmail/llmdlio/townyflight/config/Settings.java
@@ -16,6 +16,8 @@ public class Settings {
 	public static Boolean disableDuringWar;
 	public static Boolean showPermissionInMessage;
 	public static Boolean siegeWarFound;
+	public static MessageLocation messageLocation;
+	public static Boolean returnToTownMessageAppearsInTitle;
 	public static int flightDisableTimer;
 	public static List<String> allowedTempFlightAreas;
 	private static Map<String, String> lang = new HashMap<String,String>();
@@ -35,6 +37,8 @@ public class Settings {
 		showPermissionInMessage = Boolean.valueOf(getOption("show_Permission_After_No_Permission_Message"));
 		flightDisableTimer = Integer.valueOf(getOption("flight_Disable_Timer"));
 		allowedTempFlightAreas = allowedTempFlightAreas();
+		messageLocation = getMessageLocation();
+		returnToTownMessageAppearsInTitle = Boolean.valueOf(getOption("returnToAllowedArea_appears_in_title_message_override"));
 	}
 
 	public static void loadStrings() {
@@ -94,5 +98,13 @@ public class Settings {
 	
 	public static boolean isAllowedTempFlightArea(String area) {
 		return allowedTempFlightAreas.contains(area);
+	}
+	
+	public enum MessageLocation {
+		chat,actionbar,title;
+	}
+	
+	public static MessageLocation getMessageLocation() {
+		return MessageLocation.valueOf(getOption("messages_appear_in"));
 	}
 }

--- a/src/main/java/com/gmail/llmdlio/townyflight/listeners/PlayerLeaveTownListener.java
+++ b/src/main/java/com/gmail/llmdlio/townyflight/listeners/PlayerLeaveTownListener.java
@@ -8,6 +8,7 @@ import org.bukkit.event.Listener;
 
 import com.gmail.llmdlio.townyflight.TownyFlightAPI;
 import com.gmail.llmdlio.townyflight.config.Settings;
+import com.gmail.llmdlio.townyflight.config.Settings.MessageLocation;
 import com.gmail.llmdlio.townyflight.util.Message;
 import com.palmergames.bukkit.towny.event.player.PlayerExitsFromTownBorderEvent;
 
@@ -40,7 +41,10 @@ public class PlayerLeaveTownListener implements Listener {
 			if (Settings.flightDisableTimer < 1) {
 				TownyFlightAPI.getInstance().removeFlight(player, false, true, "");
 			} else {
-				Message.of(String.format(Message.getLangString("returnToAllowedArea"), Settings.flightDisableTimer)).serious().to(player);
+				if (!Settings.returnToTownMessageAppearsInTitle)
+					Message.of(String.format(Message.getLangString("returnToAllowedArea"), Settings.flightDisableTimer)).serious().to(player);
+				else 
+					Message.of(String.format(Message.getLangString("returnToAllowedArea"), Settings.flightDisableTimer)).serious().to(player, MessageLocation.title);
 				plugin.getScheduler().runLater(player, () -> TownyFlightAPI.getInstance().testForFlight(player, true), Settings.flightDisableTimer * 20);
 			}
 		}

--- a/src/main/java/com/gmail/llmdlio/townyflight/util/MessageBuilder.java
+++ b/src/main/java/com/gmail/llmdlio/townyflight/util/MessageBuilder.java
@@ -1,7 +1,10 @@
 package com.gmail.llmdlio.townyflight.util;
 
 import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
 
+import com.gmail.llmdlio.townyflight.config.Settings;
+import com.gmail.llmdlio.townyflight.config.Settings.MessageLocation;
 import com.palmergames.bukkit.towny.TownyMessaging;
 
 public class MessageBuilder {
@@ -16,9 +19,24 @@ public class MessageBuilder {
 		this.serious = true;
 		return this;
 	}
-	
+
 	public void to(CommandSender sender) {
 		Message message = build();
-		TownyMessaging.sendMessage(sender, message.getMessage());
+		MessageLocation location = Settings.messageLocation;
+		to(sender, location);
+	}
+
+	public void to(CommandSender sender, MessageLocation location) {
+		Message message = build();
+		if (!(sender instanceof Player player)) {
+			TownyMessaging.sendMessage(sender, message.getMessage());
+			return;
+		}
+		switch (location) {
+		case chat -> TownyMessaging.sendMessage(sender, message.getMessage());
+		case actionbar -> TownyMessaging.sendActionBarMessageToPlayer(player, message.getMessage());
+		case title -> TownyMessaging.sendTitle(player, "", message.getMessage());
+		default -> TownyMessaging.sendMessage(sender, message.getMessage());
+		}
 	}
 }


### PR DESCRIPTION
```
New Config Option: options.messages_appear_in
  - Default: chat
  - Where messages will appear, options are: chat, actionbar, title New Config Option:
options.returnToAllowedArea_appears_in_title_message_override
  - Default: false
  - When false, the returnToAllowedArea message will appear in the default message location, when it is true it will always appear as a title message.
```
Closes #92.