### PR TITLE
Add optional actionbar message to players who are using their tempflight.

### DIFF
--- a/src/main/java/com/gmail/llmdlio/townyflight/config/ConfigNodes.java
+++ b/src/main/java/com/gmail/llmdlio/townyflight/config/ConfigNodes.java
@@ -114,6 +114,11 @@ public enum ConfigNodes {
 			"You have been given %s of tempflight priviledges.",
 			"",
 			"# The message shown to the player when they receive temp flight."),
+	LANG_TEMPFLIGHTTIMEREMAINING(
+			"language.tempFlightTimeRemainging",
+			"%s seconds of tempflight remaining.",
+			"",
+			"# The message shown to the player in the action bar displaying flight time remaining."),
 	LANG_TEMPFLIGHTEXPIRED(
 			"language.yourTempFlightHasExpired",
 			"Your tempflight priviledges have expired.",
@@ -146,6 +151,11 @@ public enum ConfigNodes {
 			"false",
 			"",
 			"# If set to false, TownyFlight will not prevent combat of flying people."),
+	OPTIONS_TEMPFLIGHT_SHOW_TIME_REMAINING_IN_ACTIONBAR(
+			"options.show_tempflight_time_remaining_in_actionbar",
+			"false",
+			"",
+			"# When set to true, the tempflight time remaining will appear in the action bar, while the player is flying."),
 	OPTIONS_TEMPFLIGHT_ALLOWED_AREAS(
 			"options.tempflight_allowed_areas",
 			"owntown,nationtowns",

--- a/src/main/java/com/gmail/llmdlio/townyflight/config/Settings.java
+++ b/src/main/java/com/gmail/llmdlio/townyflight/config/Settings.java
@@ -15,6 +15,7 @@ public class Settings {
 	public static Boolean disableCombatPrevention;
 	public static Boolean disableDuringWar;
 	public static Boolean showPermissionInMessage;
+	public static Boolean showTempFlightTimeRemainingInActionBar; 
 	public static Boolean siegeWarFound;
 	public static int flightDisableTimer;
 	public static List<String> allowedTempFlightAreas;
@@ -34,6 +35,7 @@ public class Settings {
 		disableCombatPrevention = Boolean.valueOf(getOption("disable_Combat_Prevention"));
 		showPermissionInMessage = Boolean.valueOf(getOption("show_Permission_After_No_Permission_Message"));
 		flightDisableTimer = Integer.valueOf(getOption("flight_Disable_Timer"));
+		showTempFlightTimeRemainingInActionBar = Boolean.valueOf(getOption("show_tempflight_time_remaining_in_actionbar"));
 		allowedTempFlightAreas = allowedTempFlightAreas();
 	}
 
@@ -62,6 +64,7 @@ public class Settings {
 		lang.put("tempFlightGrantedToPlayer", getString("tempFlightGrantedToPlayer"));
 		lang.put("youHaveReceivedTempFlight", getString("youHaveReceivedTempFlight"));
 		lang.put("yourTempFlightHasExpired", getString("yourTempFlightHasExpired"));
+		lang.put("tempFlightTimeRemainging", getString("tempFlightTimeRemainging"));
 	}
 
 	public static String getLangString(String languageString) {

--- a/src/main/java/com/gmail/llmdlio/townyflight/tasks/TempFlightTask.java
+++ b/src/main/java/com/gmail/llmdlio/townyflight/tasks/TempFlightTask.java
@@ -12,10 +12,12 @@ import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 
 import com.gmail.llmdlio.townyflight.TownyFlightAPI;
+import com.gmail.llmdlio.townyflight.config.Settings;
 import com.gmail.llmdlio.townyflight.util.Message;
 import com.gmail.llmdlio.townyflight.util.MetaData;
 import com.gmail.llmdlio.townyflight.util.Permission;
 import com.palmergames.bukkit.towny.TownyAPI;
+import com.palmergames.bukkit.towny.TownyMessaging;
 import com.palmergames.bukkit.towny.object.Resident;
 
 public class TempFlightTask implements Runnable {
@@ -51,6 +53,10 @@ public class TempFlightTask implements Runnable {
 	private void decrementSeconds(UUID uuid) {
 		long seconds = playerUUIDSecondsMap.get(uuid);
 		playerUUIDSecondsMap.put(uuid, --seconds);
+
+		if (Settings.showTempFlightTimeRemainingInActionBar)
+			sendActionBarMessage(uuid, seconds);
+
 		// Save players every 10 seconds;
 		if (cycles % 10 == 0) {
 			Resident resident = TownyAPI.getInstance().getResident(uuid);
@@ -105,5 +111,14 @@ public class TempFlightTask implements Runnable {
 			return;
 		MetaData.setSeconds(resident, seconds, true);
 		playerUUIDSecondsMap.remove(player.getUniqueId());
+	}
+
+	private void sendActionBarMessage(UUID uuid, long seconds) {
+		Player player = Bukkit.getPlayer(uuid);
+		if (player == null || !player.isOnline())
+			return;
+
+		String message = String.format(Message.getLangString("tempFlightTimeRemainging"), seconds);
+		TownyMessaging.sendActionBarMessageToPlayer(player, message);
 	}
 }


### PR DESCRIPTION


Closes #93
```
New Config Option: options.show_tempflight_time_remaining_in_actionbar
  - Default false
  - When set to true, the tempflight time remaining will appear in the action bar, while the player is flying.
```