### PR TITLE
Add Canvas support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,10 @@
 			<id>papermc</id>
 			<url>https://repo.papermc.io/repository/maven-public/</url>
 		</repository>
+		<repository>
+			<id>canvasmc</id>
+			<url>https://maven.canvasmc.io/snapshots</url>
+		</repository>
         <repository>
             <id>placeholderapi</id>
             <url>https://repo.extendedclip.com/content/repositories/placeholderapi/</url>
@@ -54,9 +58,9 @@
 	</repositories>
 	<dependencies>
 		<dependency>
-			<groupId>io.papermc.paper</groupId>
-			<artifactId>paper-api</artifactId>
-			<version>1.21.8-R0.1-SNAPSHOT</version>
+			<groupId>io.canvasmc.canvas</groupId>
+			<artifactId>canvas-api</artifactId>
+			<version>1.21.11-R0.1-SNAPSHOT</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>

--- a/src/main/java/com/gmail/llmdlio/townyflight/TownyFlight.java
+++ b/src/main/java/com/gmail/llmdlio/townyflight/TownyFlight.java
@@ -1,9 +1,12 @@
 package com.gmail.llmdlio.townyflight;
 
+import com.gmail.llmdlio.townyflight.listeners.ExternalCanvasListener;
 import com.palmergames.bukkit.towny.scheduling.TaskScheduler;
 import com.palmergames.bukkit.towny.scheduling.impl.BukkitTaskScheduler;
 import com.palmergames.bukkit.towny.scheduling.impl.FoliaTaskScheduler;
 
+import io.papermc.paper.ServerBuildInfo;
+import net.kyori.adventure.key.Key;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.HandlerList;
@@ -32,6 +35,7 @@ import com.gmail.llmdlio.townyflight.util.MetaData;
 import com.palmergames.bukkit.util.Version;
 
 public class TownyFlight extends JavaPlugin {
+	private static final Key CANVAS_BRAND_ID = Key.key("canvasmc", "canvas");
 	private static final Version requiredTownyVersion = Version.fromString("0.102.0.0");
 	private TownyFlightConfig config = new TownyFlightConfig(this);
 	private static TownyFlight plugin;
@@ -118,15 +122,21 @@ public class TownyFlight extends JavaPlugin {
 	public void registerEvents() {
 		final PluginManager pm = getServer().getPluginManager();
 
+		PlayerTeleportListener playerTeleportListener = new PlayerTeleportListener();
+
 		pm.registerEvents(new PlayerJoinListener(this), this);
 		pm.registerEvents(new PlayerLogOutListener(), this);
 		pm.registerEvents(new PlayerLeaveTownListener(this), this);
 		pm.registerEvents(new TownRemoveResidentListener(this), this);
 		pm.registerEvents(new TownUnclaimListener(this), this);
 		pm.registerEvents(new PlayerFallListener(), this);
-		pm.registerEvents(new PlayerTeleportListener(), this);
+		pm.registerEvents(playerTeleportListener, this);
 		pm.registerEvents(new TownStatusScreenListener(), this);
 		pm.registerEvents(new PlayerEnterTownListener(this), this);
+
+		if (ServerBuildInfo.buildInfo().isBrandCompatible(CANVAS_BRAND_ID)) {
+			pm.registerEvents(new ExternalCanvasListener(playerTeleportListener), this);
+		}
 
 		if (Settings.disableCombatPrevention)
 			pm.registerEvents(new PlayerPVPListener(), this);

--- a/src/main/java/com/gmail/llmdlio/townyflight/TownyFlight.java
+++ b/src/main/java/com/gmail/llmdlio/townyflight/TownyFlight.java
@@ -5,7 +5,6 @@ import com.palmergames.bukkit.towny.scheduling.TaskScheduler;
 import com.palmergames.bukkit.towny.scheduling.impl.BukkitTaskScheduler;
 import com.palmergames.bukkit.towny.scheduling.impl.FoliaTaskScheduler;
 
-import io.papermc.paper.ServerBuildInfo;
 import net.kyori.adventure.key.Key;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
@@ -35,7 +34,6 @@ import com.gmail.llmdlio.townyflight.util.MetaData;
 import com.palmergames.bukkit.util.Version;
 
 public class TownyFlight extends JavaPlugin {
-	private static final Key CANVAS_BRAND_ID = Key.key("canvasmc", "canvas");
 	private static final Version requiredTownyVersion = Version.fromString("0.102.0.0");
 	private TownyFlightConfig config = new TownyFlightConfig(this);
 	private static TownyFlight plugin;
@@ -134,8 +132,11 @@ public class TownyFlight extends JavaPlugin {
 		pm.registerEvents(new TownStatusScreenListener(), this);
 		pm.registerEvents(new PlayerEnterTownListener(this), this);
 
-		if (ServerBuildInfo.buildInfo().isBrandCompatible(CANVAS_BRAND_ID)) {
+		try {
+			Class.forName("io.canvasmc.canvas.event.EntityTeleportAsyncEvent");
 			pm.registerEvents(new ExternalCanvasListener(playerTeleportListener), this);
+		} catch (ClassNotFoundException ignored) {
+			// Not a Canvas server
 		}
 
 		if (Settings.disableCombatPrevention)

--- a/src/main/java/com/gmail/llmdlio/townyflight/listeners/ExternalCanvasListener.java
+++ b/src/main/java/com/gmail/llmdlio/townyflight/listeners/ExternalCanvasListener.java
@@ -1,0 +1,40 @@
+package com.gmail.llmdlio.townyflight.listeners;
+
+import io.canvasmc.canvas.event.EntityPostPortalAsyncEvent;
+import io.canvasmc.canvas.event.EntityTeleportAsyncEvent;
+import org.bukkit.PortalType;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerTeleportEvent;
+
+public class ExternalCanvasListener implements Listener {
+
+    private final PlayerTeleportListener delegate;
+
+    public ExternalCanvasListener(PlayerTeleportListener delegate) {
+        this.delegate = delegate;
+    }
+
+    @EventHandler
+    public void playerTeleport(EntityTeleportAsyncEvent event) {
+        if (event.getEntity() instanceof Player player) {
+            delegate.handlePlayerTeleportation(event.getCause(), player, event.getTo());
+        }
+    }
+
+    // Flight will persist through portals if this isn't called.
+    @EventHandler
+    public void playerPortalTeleport(EntityPostPortalAsyncEvent event) {
+        if (event.getEntity() instanceof Player player) {
+            PlayerTeleportEvent.TeleportCause cause;
+            switch (event.getPortalType()) {
+                case NETHER -> cause = PlayerTeleportEvent.TeleportCause.NETHER_PORTAL;
+                case ENDER -> cause = PlayerTeleportEvent.TeleportCause.END_PORTAL;
+                case END_GATEWAY -> cause = PlayerTeleportEvent.TeleportCause.END_GATEWAY;
+                default -> cause = PlayerTeleportEvent.TeleportCause.PLUGIN;
+            }
+            delegate.handlePlayerTeleportation(cause, player, player.getLocation());
+        }
+    }
+}

--- a/src/main/java/com/gmail/llmdlio/townyflight/listeners/ExternalCanvasListener.java
+++ b/src/main/java/com/gmail/llmdlio/townyflight/listeners/ExternalCanvasListener.java
@@ -2,7 +2,6 @@ package com.gmail.llmdlio.townyflight.listeners;
 
 import io.canvasmc.canvas.event.EntityPostPortalAsyncEvent;
 import io.canvasmc.canvas.event.EntityTeleportAsyncEvent;
-import org.bukkit.PortalType;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;

--- a/src/main/java/com/gmail/llmdlio/townyflight/listeners/PlayerTeleportListener.java
+++ b/src/main/java/com/gmail/llmdlio/townyflight/listeners/PlayerTeleportListener.java
@@ -16,13 +16,16 @@ public class PlayerTeleportListener implements Listener {
 
 	@EventHandler(priority = EventPriority.MONITOR)
 	private void playerTeleports(PlayerTeleportEvent event) {
-		if (!aTeleportCauseThatMatters(event.getCause()))
+		handlePlayerTeleportation(event.getCause(), event.getPlayer(), event.getTo());
+	}
+
+	public void handlePlayerTeleportation(TeleportCause cause, Player player, Location to) {
+		if (!aTeleportCauseThatMatters(cause))
 			return;
 
-		Player player = event.getPlayer();
-		if (player.hasPermission("townyflight.bypass") 
+		if (player.hasPermission("townyflight.bypass")
 				|| !player.getAllowFlight()
-				|| flightAllowedDestination(player, event.getTo())) {
+				|| flightAllowedDestination(player, to)) {
 			return;
 		}
 

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -6,6 +6,7 @@ api-version: ${project.bukkitAPIVersion}
 depend: [Towny]
 softdepend: [SiegeWar]
 prefix: TownyFlight
+canvas-supported: true
 
 commands:
   tfly:


### PR DESCRIPTION
This PR adds support for Canvas (https://canvasmc.io). Folia support was seemingly removed from TownyFlight due to missing events on Folia. Canvas re-implements these events and is a popular fork among Folia-based servers because of this. This PR only adds supports for Canvas and does not add support for base folia. Canvas will load plugins with `canvas-supported: true` since build 669.