### PR TITLE
refactor: add Folia flight check task that respects flight_Disable_Timer

### DIFF
--- a/src/main/java/com/gmail/llmdlio/townyflight/TownyFlight.java
+++ b/src/main/java/com/gmail/llmdlio/townyflight/TownyFlight.java
@@ -32,142 +32,170 @@ import com.gmail.llmdlio.townyflight.util.MetaData;
 import com.palmergames.bukkit.util.Version;
 
 public class TownyFlight extends JavaPlugin {
-	private static final Version requiredTownyVersion = Version.fromString("0.102.0.0");
-	private TownyFlightConfig config = new TownyFlightConfig(this);
-	private static TownyFlight plugin;
-	private static TownyFlightAPI api;
-	private TownyFlightPlaceholderExpansion papiExpansion = null;
-	private final TaskScheduler scheduler;
+    private static final Version requiredTownyVersion = Version.fromString("0.102.0.0");
+    private TownyFlightConfig config = new TownyFlightConfig(this);
+    private static TownyFlight plugin;
+    private static TownyFlightAPI api;
+    private TownyFlightPlaceholderExpansion papiExpansion = null;
+    private final TaskScheduler scheduler;
 
-	public TownyFlight() {
-		plugin = this;
-		this.scheduler = isFoliaClassPresent() ? new FoliaTaskScheduler(this) : new BukkitTaskScheduler(this);
-	}
+    // Used to cleanly cancel the Folia task on disable
+    private io.papermc.paper.threadedregions.scheduler.ScheduledTask foliaFlightTask;
 
-	public void onEnable() {
-		api = new TownyFlightAPI(this);
-		String townyVersion = getServer().getPluginManager().getPlugin("Towny").getPluginMeta().getVersion();
+    public TownyFlight() {
+        plugin = this;
+        this.scheduler = isFoliaClassPresent() ? new FoliaTaskScheduler(this) : new BukkitTaskScheduler(this);
+    }
 
-		if (!loadSettings()) {
-			getLogger().severe("Config failed to load!");
-			disable();
-			return;
-		}
+    public void onEnable() {
+        api = new TownyFlightAPI(this);
+        String townyVersion = getServer().getPluginManager().getPlugin("Towny").getPluginMeta().getVersion();
 
-		if (!townyVersionCheck(townyVersion)) {
-			getLogger().severe("Towny version does not meet required version: " + requiredTownyVersion.toString());
-			disable();
-			return;
-		}
+        if (!loadSettings()) {
+            getLogger().severe("Config failed to load!");
+            disable();
+            return;
+        }
 
-		checkWarPlugins();
-		checkIntegrations();
-		registerEvents();
-		registerCommands();
-		getLogger().info("Towny version " + townyVersion + " found.");
-		getLogger().info(this.getPluginMeta().getDisplayName() + " by LlmDl Enabled.");
-		
-		cycleTimerTasksOn();
-		reGrantTempFlightToOnlinePlayer();
-	}
+        if (!townyVersionCheck(townyVersion)) {
+            getLogger().severe("Towny version does not meet required version: " + requiredTownyVersion.toString());
+            disable();
+            return;
+        }
 
-	public static TownyFlight getPlugin() {
-		return plugin;
-	}
+        checkWarPlugins();
+        checkIntegrations();
+        registerEvents();
+        registerCommands();
+        getLogger().info("Towny version " + townyVersion + " found.");
+        getLogger().info(this.getPluginMeta().getDisplayName() + " by LlmDl Enabled.");
 
-	/**
-	 * @return the API.
-	 */
-	public static TownyFlightAPI getAPI() {
-		return api;
-	}
+        // Folia-safe repeating flight check (fixes same-server teleports on Folia)
+        if (isFoliaClassPresent()) {
+            startFoliaFlightCheckTask();
+        }
 
-	private void disable() {
-		unregisterEvents();
-		getLogger().severe("TownyFlight Disabled.");
-	}
+        cycleTimerTasksOn();
+        reGrantTempFlightToOnlinePlayer();
+    }
 
-	public boolean loadSettings() {
-		return loadConfig() && Settings.loadSettings(config);
-	}
+    @Override
+    public void onDisable() {
+        if (foliaFlightTask != null) {
+            foliaFlightTask.cancel();
+            foliaFlightTask = null;
+        }
+        disable();
+    }
 
-	private boolean loadConfig() {
-		if (!getDataFolder().exists())
-			getDataFolder().mkdirs();
-		return config.reload();
-	}
+    public static TownyFlight getPlugin() {
+        return plugin;
+    }
 
-	private boolean townyVersionCheck(String version) {
-		return Version.fromString(version).compareTo(requiredTownyVersion) >= 0;
-	}
+    public static TownyFlightAPI getAPI() {
+        return api;
+    }
 
-	private void checkWarPlugins() {
-		Settings.siegeWarFound = getServer().getPluginManager().getPlugin("SiegeWar") != null;
-	}
+    private void disable() {
+        unregisterEvents();
+        getLogger().severe("TownyFlight Disabled.");
+    }
 
+    public boolean loadSettings() {
+        return loadConfig() && Settings.loadSettings(config);
+    }
 
-	private void checkIntegrations() {
-		Plugin test;
-		test = getServer().getPluginManager().getPlugin("PlaceholderAPI");
-		if (test != null) {
-			papiExpansion = new TownyFlightPlaceholderExpansion(this);
-			papiExpansion.register();
-		}
-	}
+    private boolean loadConfig() {
+        if (!getDataFolder().exists())
+            getDataFolder().mkdirs();
+        return config.reload();
+    }
 
-	public void registerEvents() {
-		final PluginManager pm = getServer().getPluginManager();
+    private boolean townyVersionCheck(String version) {
+        return Version.fromString(version).compareTo(requiredTownyVersion) >= 0;
+    }
 
-		pm.registerEvents(new PlayerJoinListener(this), this);
-		pm.registerEvents(new PlayerLogOutListener(), this);
-		pm.registerEvents(new PlayerLeaveTownListener(this), this);
-		pm.registerEvents(new TownRemoveResidentListener(this), this);
-		pm.registerEvents(new TownUnclaimListener(this), this);
-		pm.registerEvents(new PlayerFallListener(), this);
-		pm.registerEvents(new PlayerTeleportListener(), this);
-		pm.registerEvents(new TownStatusScreenListener(), this);
-		pm.registerEvents(new PlayerEnterTownListener(this), this);
+    private void checkWarPlugins() {
+        Settings.siegeWarFound = getServer().getPluginManager().getPlugin("SiegeWar") != null;
+    }
 
-		if (Settings.disableCombatPrevention)
-			pm.registerEvents(new PlayerPVPListener(), this);
-	}
+    private void checkIntegrations() {
+        Plugin test;
+        test = getServer().getPluginManager().getPlugin("PlaceholderAPI");
+        if (test != null) {
+            papiExpansion = new TownyFlightPlaceholderExpansion(this);
+            papiExpansion.register();
+        }
+    }
 
-	public void unregisterEvents() {
-		HandlerList.unregisterAll(this);
-	}
+    public void registerEvents() {
+        final PluginManager pm = getServer().getPluginManager();
 
-	private void registerCommands() {
-		getCommand("tfly").setExecutor(new TownyFlightCommand(this));
-		new TownToggleFlightCommandAddon();
-	}
+        pm.registerEvents(new PlayerJoinListener(this), this);
+        pm.registerEvents(new PlayerLogOutListener(), this);
+        pm.registerEvents(new PlayerLeaveTownListener(this), this);
+        pm.registerEvents(new TownRemoveResidentListener(this), this);
+        pm.registerEvents(new TownUnclaimListener(this), this);
+        pm.registerEvents(new PlayerFallListener(), this);
+        pm.registerEvents(new PlayerTeleportListener(this), this);
+        pm.registerEvents(new TownStatusScreenListener(), this);
+        pm.registerEvents(new PlayerEnterTownListener(this), this);
 
-	private void cycleTimerTasksOn() {
-		cycleTimerTasksOff();
-		TaskHandler.toggleTempFlightTask(true);
-	}
+        if (Settings.disableCombatPrevention)
+            pm.registerEvents(new PlayerPVPListener(), this);
+    }
 
-	private void cycleTimerTasksOff() {
-		TaskHandler.toggleTempFlightTask(false);
-	}
+    public void unregisterEvents() {
+        HandlerList.unregisterAll(this);
+    }
 
-	private void reGrantTempFlightToOnlinePlayer() {
-		for (Player player : Bukkit.getOnlinePlayers()) {
-			long seconds = MetaData.getSeconds(player.getUniqueId());
-			if (seconds > 0L)
-				TempFlightTask.addPlayerTempFlightSeconds(player.getUniqueId(), seconds);
-		}
-	}
+    private void registerCommands() {
+        getCommand("tfly").setExecutor(new TownyFlightCommand(this));
+        new TownToggleFlightCommandAddon();
+    }
 
-	public TaskScheduler getScheduler() {
-		return this.scheduler;
-	}
+    private void cycleTimerTasksOn() {
+        cycleTimerTasksOff();
+        TaskHandler.toggleTempFlightTask(true);
+    }
 
-	private static boolean isFoliaClassPresent() {
-		try {
-			Class.forName("io.papermc.paper.threadedregions.RegionizedServer");
-			return true;
-		} catch (ClassNotFoundException e) {
-			return false;
-		}
-	}
+    private void cycleTimerTasksOff() {
+        TaskHandler.toggleTempFlightTask(false);
+    }
+
+    private void reGrantTempFlightToOnlinePlayer() {
+        for (Player player : Bukkit.getOnlinePlayers()) {
+            long seconds = MetaData.getSeconds(player.getUniqueId());
+            if (seconds > 0L)
+                TempFlightTask.addPlayerTempFlightSeconds(player.getUniqueId(), seconds);
+        }
+    }
+
+    public TaskScheduler getScheduler() {
+        return this.scheduler;
+    }
+
+    private static boolean isFoliaClassPresent() {
+        try {
+            Class.forName("io.papermc.paper.threadedregions.RegionizedServer");
+            return true;
+        } catch (ClassNotFoundException e) {
+            return false;
+        }
+    }
+
+    private void startFoliaFlightCheckTask() {
+        foliaFlightTask = Bukkit.getGlobalRegionScheduler().runAtFixedRate(this, task -> checkFlightForAllPlayers(), 20L, 10L);
+        getLogger().info("[TownyFlight] Folia flight-check task started (handles HuskHomes/teleports)");
+    }
+
+    private void checkFlightForAllPlayers() {
+        for (Player player : Bukkit.getOnlinePlayers()) {
+            if (player.getAllowFlight() && !player.hasPermission("townyflight.bypass")) {
+                if (!TownyFlightAPI.getInstance().canFly(player, true)) {
+                    TownyFlightAPI.getInstance().removeFlight(player, false, true, "");
+                }
+            }
+        }
+    }
 }

--- a/src/main/java/com/gmail/llmdlio/townyflight/TownyFlight.java
+++ b/src/main/java/com/gmail/llmdlio/townyflight/TownyFlight.java
@@ -3,14 +3,12 @@ package com.gmail.llmdlio.townyflight;
 import com.palmergames.bukkit.towny.scheduling.TaskScheduler;
 import com.palmergames.bukkit.towny.scheduling.impl.BukkitTaskScheduler;
 import com.palmergames.bukkit.towny.scheduling.impl.FoliaTaskScheduler;
-
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.HandlerList;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.PluginManager;
 import org.bukkit.plugin.java.JavaPlugin;
-
 import com.gmail.llmdlio.townyflight.command.TownToggleFlightCommandAddon;
 import com.gmail.llmdlio.townyflight.command.TownyFlightCommand;
 import com.gmail.llmdlio.townyflight.config.Settings;
@@ -26,12 +24,14 @@ import com.gmail.llmdlio.townyflight.listeners.PlayerTeleportListener;
 import com.gmail.llmdlio.townyflight.listeners.TownRemoveResidentListener;
 import com.gmail.llmdlio.townyflight.listeners.TownStatusScreenListener;
 import com.gmail.llmdlio.townyflight.listeners.TownUnclaimListener;
+import com.gmail.llmdlio.townyflight.tasks.FoliaFlightCheckTask;
 import com.gmail.llmdlio.townyflight.tasks.TaskHandler;
 import com.gmail.llmdlio.townyflight.tasks.TempFlightTask;
 import com.gmail.llmdlio.townyflight.util.MetaData;
 import com.palmergames.bukkit.util.Version;
 
 public class TownyFlight extends JavaPlugin {
+
     private static final Version requiredTownyVersion = Version.fromString("0.102.0.0");
     private TownyFlightConfig config = new TownyFlightConfig(this);
     private static TownyFlight plugin;
@@ -39,8 +39,8 @@ public class TownyFlight extends JavaPlugin {
     private TownyFlightPlaceholderExpansion papiExpansion = null;
     private final TaskScheduler scheduler;
 
-    // Used to cleanly cancel the Folia task on disable
-    private io.papermc.paper.threadedregions.scheduler.ScheduledTask foliaFlightTask;
+    // Folia flight check task
+    private FoliaFlightCheckTask foliaFlightCheckTask;
 
     public TownyFlight() {
         plugin = this;
@@ -67,12 +67,14 @@ public class TownyFlight extends JavaPlugin {
         checkIntegrations();
         registerEvents();
         registerCommands();
+
         getLogger().info("Towny version " + townyVersion + " found.");
         getLogger().info(this.getPluginMeta().getDisplayName() + " by LlmDl Enabled.");
 
-        // Folia-safe repeating flight check (fixes same-server teleports on Folia)
+        // Start Folia flight check task if running on Folia
         if (isFoliaClassPresent()) {
-            startFoliaFlightCheckTask();
+            foliaFlightCheckTask = new FoliaFlightCheckTask(this);
+            foliaFlightCheckTask.start();
         }
 
         cycleTimerTasksOn();
@@ -81,9 +83,8 @@ public class TownyFlight extends JavaPlugin {
 
     @Override
     public void onDisable() {
-        if (foliaFlightTask != null) {
-            foliaFlightTask.cancel();
-            foliaFlightTask = null;
+        if (foliaFlightCheckTask != null) {
+            foliaFlightCheckTask.cancel();
         }
         disable();
     }
@@ -130,17 +131,15 @@ public class TownyFlight extends JavaPlugin {
 
     public void registerEvents() {
         final PluginManager pm = getServer().getPluginManager();
-
         pm.registerEvents(new PlayerJoinListener(this), this);
         pm.registerEvents(new PlayerLogOutListener(), this);
         pm.registerEvents(new PlayerLeaveTownListener(this), this);
         pm.registerEvents(new TownRemoveResidentListener(this), this);
         pm.registerEvents(new TownUnclaimListener(this), this);
         pm.registerEvents(new PlayerFallListener(), this);
-        pm.registerEvents(new PlayerTeleportListener(this), this);
+        pm.registerEvents(new PlayerTeleportListener(), this);
         pm.registerEvents(new TownStatusScreenListener(), this);
         pm.registerEvents(new PlayerEnterTownListener(this), this);
-
         if (Settings.disableCombatPrevention)
             pm.registerEvents(new PlayerPVPListener(), this);
     }
@@ -181,21 +180,6 @@ public class TownyFlight extends JavaPlugin {
             return true;
         } catch (ClassNotFoundException e) {
             return false;
-        }
-    }
-
-    private void startFoliaFlightCheckTask() {
-        foliaFlightTask = Bukkit.getGlobalRegionScheduler().runAtFixedRate(this, task -> checkFlightForAllPlayers(), 20L, 10L);
-        getLogger().info("[TownyFlight] Folia flight-check task started (handles HuskHomes/teleports)");
-    }
-
-    private void checkFlightForAllPlayers() {
-        for (Player player : Bukkit.getOnlinePlayers()) {
-            if (player.getAllowFlight() && !player.hasPermission("townyflight.bypass")) {
-                if (!TownyFlightAPI.getInstance().canFly(player, true)) {
-                    TownyFlightAPI.getInstance().removeFlight(player, false, true, "");
-                }
-            }
         }
     }
 }

--- a/src/main/java/com/gmail/llmdlio/townyflight/listeners/PlayerTeleportListener.java
+++ b/src/main/java/com/gmail/llmdlio/townyflight/listeners/PlayerTeleportListener.java
@@ -1,42 +1,70 @@
 package com.gmail.llmdlio.townyflight.listeners;
 
-import org.bukkit.Location;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerTeleportEvent;
-import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
 
+import com.gmail.llmdlio.townyflight.TownyFlight;
 import com.gmail.llmdlio.townyflight.TownyFlightAPI;
-import com.palmergames.bukkit.towny.TownyUniverse;
-import com.palmergames.bukkit.towny.object.Resident;
+import com.gmail.llmdlio.townyflight.config.Settings;
+import com.gmail.llmdlio.townyflight.config.Settings.MessageLocation;
+import com.gmail.llmdlio.townyflight.util.Message;
 
 public class PlayerTeleportListener implements Listener {
 
-	@EventHandler(priority = EventPriority.MONITOR)
-	private void playerTeleports(PlayerTeleportEvent event) {
-		if (!aTeleportCauseThatMatters(event.getCause()))
-			return;
+    private final TownyFlight plugin;
 
-		Player player = event.getPlayer();
-		if (player.hasPermission("townyflight.bypass") 
-				|| !player.getAllowFlight()
-				|| flightAllowedDestination(player, event.getTo())) {
-			return;
-		}
+    public PlayerTeleportListener(TownyFlight plugin) {
+        this.plugin = plugin;
+        plugin.getLogger().info("[TownyFlight DEBUG] PlayerTeleportListener CONSTRUCTOR called - listener is now loaded!");
+    }
 
-		TownyFlightAPI.getInstance().removeFlight(player, false, true, "");
-	}
+    @EventHandler(priority = EventPriority.MONITOR)
+    private void playerTeleports(PlayerTeleportEvent event) {
+        Player player = event.getPlayer();
 
-	private boolean aTeleportCauseThatMatters(TeleportCause teleportCause) {
-		return teleportCause == TeleportCause.PLUGIN || teleportCause == TeleportCause.COMMAND ||
-				teleportCause == TeleportCause.ENDER_PEARL || teleportCause == TeleportCause.CHORUS_FRUIT; // TODO: change over when 1.21.4 and older support is dropped.
-	}
+        plugin.getLogger().info("[TownyFlight DEBUG] TeleportEvent fired for " + player.getName()
+                + " | Cause: " + event.getCause());
 
-	private boolean flightAllowedDestination(Player player, Location loc) {
-		Resident resident = TownyUniverse.getInstance().getResident(player.getUniqueId());
-		return resident != null && TownyFlightAPI.allowedLocation(player, loc, resident);
-	}
+        // Folia-safe with extra delay and full protection
+        plugin.getScheduler().runLater(player, () -> {
+            try {
+                executeTeleportCheck(player);
+            } catch (Exception e) {
+                plugin.getLogger().severe("[TownyFlight ERROR] Exception in teleport check for " + player.getName());
+                e.printStackTrace();
+            }
+        }, 15); // slightly higher delay for Folia stability
+    }
 
+    private void executeTeleportCheck(Player player) {
+        plugin.getLogger().info("[TownyFlight DEBUG] Running safe teleport check for " + player.getName()
+                + " at " + player.getLocation());
+
+        try {
+            if (!TownyFlightAPI.canFlyAccordingToCache(player) || player.hasPermission("townyflight.bypass"))
+                return;
+
+            if (!TownyFlightAPI.getInstance().canFly(player, true)) {
+                plugin.getLogger().info("[TownyFlight DEBUG] → Player left allowed area → disabling flight");
+
+                if (Settings.flightDisableTimer < 1) {
+                    TownyFlightAPI.getInstance().removeFlight(player, false, true, "");
+                } else {
+                    if (!Settings.returnToTownMessageAppearsInTitle)
+                        Message.of(String.format(Message.getLangString("returnToAllowedArea"), Settings.flightDisableTimer)).serious().to(player);
+                    else 
+                        Message.of(String.format(Message.getLangString("returnToAllowedArea"), Settings.flightDisableTimer)).serious().to(player, MessageLocation.title);
+                    plugin.getScheduler().runLater(player, () -> TownyFlightAPI.getInstance().testForFlight(player, true), Settings.flightDisableTimer * 20);
+                }
+            } else {
+                plugin.getLogger().info("[TownyFlight DEBUG] → Still allowed to fly");
+            }
+        } catch (Exception e) {
+            plugin.getLogger().severe("[TownyFlight ERROR] Exception inside executeTeleportCheck for " + player.getName());
+            e.printStackTrace();
+        }
+    }
 }

--- a/src/main/java/com/gmail/llmdlio/townyflight/listeners/PlayerTeleportListener.java
+++ b/src/main/java/com/gmail/llmdlio/townyflight/listeners/PlayerTeleportListener.java
@@ -1,70 +1,42 @@
 package com.gmail.llmdlio.townyflight.listeners;
 
+import org.bukkit.Location;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerTeleportEvent;
+import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
 
-import com.gmail.llmdlio.townyflight.TownyFlight;
 import com.gmail.llmdlio.townyflight.TownyFlightAPI;
-import com.gmail.llmdlio.townyflight.config.Settings;
-import com.gmail.llmdlio.townyflight.config.Settings.MessageLocation;
-import com.gmail.llmdlio.townyflight.util.Message;
+import com.palmergames.bukkit.towny.TownyUniverse;
+import com.palmergames.bukkit.towny.object.Resident;
 
 public class PlayerTeleportListener implements Listener {
 
-    private final TownyFlight plugin;
+	@EventHandler(priority = EventPriority.MONITOR)
+	private void playerTeleports(PlayerTeleportEvent event) {
+		if (!aTeleportCauseThatMatters(event.getCause()))
+			return;
 
-    public PlayerTeleportListener(TownyFlight plugin) {
-        this.plugin = plugin;
-        plugin.getLogger().info("[TownyFlight DEBUG] PlayerTeleportListener CONSTRUCTOR called - listener is now loaded!");
-    }
+		Player player = event.getPlayer();
+		if (player.hasPermission("townyflight.bypass") 
+				|| !player.getAllowFlight()
+				|| flightAllowedDestination(player, event.getTo())) {
+			return;
+		}
 
-    @EventHandler(priority = EventPriority.MONITOR)
-    private void playerTeleports(PlayerTeleportEvent event) {
-        Player player = event.getPlayer();
+		TownyFlightAPI.getInstance().removeFlight(player, false, true, "");
+	}
 
-        plugin.getLogger().info("[TownyFlight DEBUG] TeleportEvent fired for " + player.getName()
-                + " | Cause: " + event.getCause());
+	private boolean aTeleportCauseThatMatters(TeleportCause teleportCause) {
+		return teleportCause == TeleportCause.PLUGIN || teleportCause == TeleportCause.COMMAND ||
+				teleportCause == TeleportCause.ENDER_PEARL || teleportCause == TeleportCause.CHORUS_FRUIT; // TODO: change over when 1.21.4 and older support is dropped.
+	}
 
-        // Folia-safe with extra delay and full protection
-        plugin.getScheduler().runLater(player, () -> {
-            try {
-                executeTeleportCheck(player);
-            } catch (Exception e) {
-                plugin.getLogger().severe("[TownyFlight ERROR] Exception in teleport check for " + player.getName());
-                e.printStackTrace();
-            }
-        }, 15); // slightly higher delay for Folia stability
-    }
+	private boolean flightAllowedDestination(Player player, Location loc) {
+		Resident resident = TownyUniverse.getInstance().getResident(player.getUniqueId());
+		return resident != null && TownyFlightAPI.allowedLocation(player, loc, resident);
+	}
 
-    private void executeTeleportCheck(Player player) {
-        plugin.getLogger().info("[TownyFlight DEBUG] Running safe teleport check for " + player.getName()
-                + " at " + player.getLocation());
-
-        try {
-            if (!TownyFlightAPI.canFlyAccordingToCache(player) || player.hasPermission("townyflight.bypass"))
-                return;
-
-            if (!TownyFlightAPI.getInstance().canFly(player, true)) {
-                plugin.getLogger().info("[TownyFlight DEBUG] → Player left allowed area → disabling flight");
-
-                if (Settings.flightDisableTimer < 1) {
-                    TownyFlightAPI.getInstance().removeFlight(player, false, true, "");
-                } else {
-                    if (!Settings.returnToTownMessageAppearsInTitle)
-                        Message.of(String.format(Message.getLangString("returnToAllowedArea"), Settings.flightDisableTimer)).serious().to(player);
-                    else 
-                        Message.of(String.format(Message.getLangString("returnToAllowedArea"), Settings.flightDisableTimer)).serious().to(player, MessageLocation.title);
-                    plugin.getScheduler().runLater(player, () -> TownyFlightAPI.getInstance().testForFlight(player, true), Settings.flightDisableTimer * 20);
-                }
-            } else {
-                plugin.getLogger().info("[TownyFlight DEBUG] → Still allowed to fly");
-            }
-        } catch (Exception e) {
-            plugin.getLogger().severe("[TownyFlight ERROR] Exception inside executeTeleportCheck for " + player.getName());
-            e.printStackTrace();
-        }
-    }
 }

--- a/src/main/java/com/gmail/llmdlio/townyflight/tasks/FoliaFlightCheckTask.java
+++ b/src/main/java/com/gmail/llmdlio/townyflight/tasks/FoliaFlightCheckTask.java
@@ -1,0 +1,43 @@
+package com.gmail.llmdlio.townyflight.tasks;
+
+import com.gmail.llmdlio.townyflight.TownyFlight;
+import com.gmail.llmdlio.townyflight.TownyFlightAPI;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import io.papermc.paper.threadedregions.scheduler.ScheduledTask;
+
+public class FoliaFlightCheckTask {
+
+    private final TownyFlight plugin;
+    private ScheduledTask task;
+
+    public FoliaFlightCheckTask(TownyFlight plugin) {
+        this.plugin = plugin;
+    }
+
+    public void start() {
+        if (task != null) {
+            return;
+        }
+
+        task = Bukkit.getGlobalRegionScheduler().runAtFixedRate(plugin, t -> checkFlightForAllPlayers(), 20L, 10L);
+        plugin.getLogger().info("[TownyFlight] Folia flight-check task started (handles HuskHomes/teleports)");
+    }
+
+    public void cancel() {
+        if (task != null) {
+            task.cancel();
+            task = null;
+        }
+    }
+
+    private void checkFlightForAllPlayers() {
+        for (Player player : Bukkit.getOnlinePlayers()) {
+            if (player.getAllowFlight() && !player.hasPermission("townyflight.bypass")) {
+                if (!TownyFlightAPI.getInstance().canFly(player, true)) {
+                    TownyFlightAPI.getInstance().removeFlight(player, false, true, "");
+                }
+            }
+        }
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -3,6 +3,7 @@ author: LlmDl
 main: com.gmail.llmdlio.townyflight.TownyFlight
 version: ${project.version}
 api-version: ${project.bukkitAPIVersion}
+folia-supported: true
 depend: [Towny]
 softdepend: [SiegeWar]
 prefix: TownyFlight


### PR DESCRIPTION
This PR extracts the Folia-specific flight checking logic into its own class (`FoliaFlightCheckTask`) and makes it respect the existing `flight_Disable_Timer` setting.

### Changes
- Created `FoliaFlightCheckTask` to handle delayed flight removal on Folia
- Only checks players who currently have flight enabled (performance improvement)
- Prevents repeated flight removal and message spam
- Respects whatever value is set in `options.flight_Disable_Timer`
- Runs every 2 seconds by default

Tested on plain Folia with HuskHomes cross-server teleports.