### PR TITLE
Pause temporary flight time while Essentials AFK

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,10 @@
 			<id>glaremasters repo</id>
 			<url>https://repo.glaremasters.me/repository/towny/</url>
 		</repository>
+		<repository>
+			<id>essentialsx-releases</id>
+			<url>https://repo.essentialsx.net/releases/</url>
+		</repository>
 	</repositories>
 	<dependencies>
 		<dependency>
@@ -81,6 +85,12 @@
             <groupId>me.clip</groupId>
             <artifactId>placeholderapi</artifactId>
             <version>2.11.6</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>net.essentialsx</groupId>
+            <artifactId>EssentialsX</artifactId>
+            <version>2.21.2</version>
             <scope>provided</scope>
         </dependency>
 	</dependencies>

--- a/src/main/java/com/gmail/llmdlio/townyflight/TownyFlight.java
+++ b/src/main/java/com/gmail/llmdlio/townyflight/TownyFlight.java
@@ -15,6 +15,7 @@ import com.gmail.llmdlio.townyflight.command.TownToggleFlightCommandAddon;
 import com.gmail.llmdlio.townyflight.command.TownyFlightCommand;
 import com.gmail.llmdlio.townyflight.config.Settings;
 import com.gmail.llmdlio.townyflight.config.TownyFlightConfig;
+import com.gmail.llmdlio.townyflight.integrations.EssentialsIntegration;
 import com.gmail.llmdlio.townyflight.integrations.TownyFlightPlaceholderExpansion;
 import com.gmail.llmdlio.townyflight.listeners.PlayerEnterTownListener;
 import com.gmail.llmdlio.townyflight.listeners.PlayerFallListener;
@@ -113,6 +114,10 @@ public class TownyFlight extends JavaPlugin {
 			papiExpansion = new TownyFlightPlaceholderExpansion(this);
 			papiExpansion.register();
 		}
+		test = getServer().getPluginManager().getPlugin("Essentials");
+		Settings.essentialsFound = test != null;
+		if (Settings.essentialsFound)
+			EssentialsIntegration.initialize(test);
 	}
 
 	public void registerEvents() {

--- a/src/main/java/com/gmail/llmdlio/townyflight/config/ConfigNodes.java
+++ b/src/main/java/com/gmail/llmdlio/townyflight/config/ConfigNodes.java
@@ -160,8 +160,8 @@ public enum ConfigNodes {
 			"options.pause_tempflight_time_while_afk",
 			"false",
 			"",
-			"# When true, tempflight time will not decrease while a player is marked as AFK by EssentialsX.",
-			"# This option has no effect when EssentialsX is not installed."),
+			"# When true, tempflight time will not decrease while a player is marked as AFK.",
+			"# This option currently only supports EssentialsX's afk status."),
 	OPTIONS_TEMPFLIGHT_ALLOWED_AREAS(
 			"options.tempflight_allowed_areas",
 			"owntown,nationtowns",

--- a/src/main/java/com/gmail/llmdlio/townyflight/config/ConfigNodes.java
+++ b/src/main/java/com/gmail/llmdlio/townyflight/config/ConfigNodes.java
@@ -156,6 +156,12 @@ public enum ConfigNodes {
 			"false",
 			"",
 			"# When set to true, the tempflight time remaining will appear in the action bar, while the player is flying."),
+	OPTIONS_TEMPFLIGHT_PAUSE_TIME_WHILE_ESSENTIALS_AFK(
+			"options.pause_tempflight_time_while_essentials_afk",
+			"false",
+			"",
+			"# When true, tempflight time will not decrease while a player is marked as AFK by EssentialsX.",
+			"# This option has no effect when EssentialsX is not installed."),
 	OPTIONS_TEMPFLIGHT_ALLOWED_AREAS(
 			"options.tempflight_allowed_areas",
 			"owntown,nationtowns",

--- a/src/main/java/com/gmail/llmdlio/townyflight/config/ConfigNodes.java
+++ b/src/main/java/com/gmail/llmdlio/townyflight/config/ConfigNodes.java
@@ -156,7 +156,7 @@ public enum ConfigNodes {
 			"false",
 			"",
 			"# When set to true, the tempflight time remaining will appear in the action bar, while the player is flying."),
-	OPTIONS_TEMPFLIGHT_PAUSE_TIME_WHILE_ESSENTIALS_AFK(
+	OPTIONS_TEMPFLIGHT_PAUSE_TIME_WHILE_AFK(
 			"options.pause_tempflight_time_while_afk",
 			"false",
 			"",

--- a/src/main/java/com/gmail/llmdlio/townyflight/config/ConfigNodes.java
+++ b/src/main/java/com/gmail/llmdlio/townyflight/config/ConfigNodes.java
@@ -157,7 +157,7 @@ public enum ConfigNodes {
 			"",
 			"# When set to true, the tempflight time remaining will appear in the action bar, while the player is flying."),
 	OPTIONS_TEMPFLIGHT_PAUSE_TIME_WHILE_ESSENTIALS_AFK(
-			"options.pause_tempflight_time_while_essentials_afk",
+			"options.pause_tempflight_time_while_afk",
 			"false",
 			"",
 			"# When true, tempflight time will not decrease while a player is marked as AFK by EssentialsX.",

--- a/src/main/java/com/gmail/llmdlio/townyflight/config/Settings.java
+++ b/src/main/java/com/gmail/llmdlio/townyflight/config/Settings.java
@@ -17,8 +17,10 @@ public class Settings {
 	public static Boolean showPermissionInMessage;
 	public static Boolean showTempFlightTimeRemainingInActionBar; 
 	public static Boolean siegeWarFound;
+	public static boolean essentialsFound;
 	public static MessageLocation messageLocation;
 	public static Boolean returnToTownMessageAppearsInTitle;
+	public static Boolean pauseTempFlightTimeWhileEssentialsAFK;
 	public static int flightDisableTimer;
 	public static List<String> allowedTempFlightAreas;
 	private static Map<String, String> lang = new HashMap<String,String>();
@@ -38,6 +40,7 @@ public class Settings {
 		showPermissionInMessage = Boolean.valueOf(getOption("show_Permission_After_No_Permission_Message"));
 		flightDisableTimer = Integer.valueOf(getOption("flight_Disable_Timer"));
 		showTempFlightTimeRemainingInActionBar = Boolean.valueOf(getOption("show_tempflight_time_remaining_in_actionbar"));
+		pauseTempFlightTimeWhileEssentialsAFK = Boolean.valueOf(getOption("pause_tempflight_time_while_essentials_afk"));
 		allowedTempFlightAreas = allowedTempFlightAreas();
 		messageLocation = getMessageLocation();
 		returnToTownMessageAppearsInTitle = Boolean.valueOf(getOption("returnToAllowedArea_appears_in_title_message_override"));

--- a/src/main/java/com/gmail/llmdlio/townyflight/config/Settings.java
+++ b/src/main/java/com/gmail/llmdlio/townyflight/config/Settings.java
@@ -40,7 +40,7 @@ public class Settings {
 		showPermissionInMessage = Boolean.valueOf(getOption("show_Permission_After_No_Permission_Message"));
 		flightDisableTimer = Integer.valueOf(getOption("flight_Disable_Timer"));
 		showTempFlightTimeRemainingInActionBar = Boolean.valueOf(getOption("show_tempflight_time_remaining_in_actionbar"));
-		pauseTempFlightTimeWhileEssentialsAFK = Boolean.valueOf(getOption("pause_tempflight_time_while_essentials_afk"));
+		pauseTempFlightTimeWhileEssentialsAFK = Boolean.valueOf(getOption("pause_tempflight_time_while_afk"));
 		allowedTempFlightAreas = allowedTempFlightAreas();
 		messageLocation = getMessageLocation();
 		returnToTownMessageAppearsInTitle = Boolean.valueOf(getOption("returnToAllowedArea_appears_in_title_message_override"));

--- a/src/main/java/com/gmail/llmdlio/townyflight/integrations/EssentialsIntegration.java
+++ b/src/main/java/com/gmail/llmdlio/townyflight/integrations/EssentialsIntegration.java
@@ -1,0 +1,23 @@
+package com.gmail.llmdlio.townyflight.integrations;
+
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.Plugin;
+
+import com.earth2me.essentials.IEssentials;
+
+public final class EssentialsIntegration {
+
+	private static IEssentials essentials;
+
+	private EssentialsIntegration() {
+	}
+
+	public static void initialize(Plugin plugin) {
+		if (plugin instanceof IEssentials)
+			essentials = (IEssentials) plugin;
+	}
+
+	public static boolean isAfk(Player player) {
+		return essentials != null && essentials.getUser(player).isAfk();
+	}
+}

--- a/src/main/java/com/gmail/llmdlio/townyflight/tasks/TempFlightTask.java
+++ b/src/main/java/com/gmail/llmdlio/townyflight/tasks/TempFlightTask.java
@@ -13,6 +13,7 @@ import org.bukkit.entity.Player;
 
 import com.gmail.llmdlio.townyflight.TownyFlightAPI;
 import com.gmail.llmdlio.townyflight.config.Settings;
+import com.gmail.llmdlio.townyflight.integrations.EssentialsIntegration;
 import com.gmail.llmdlio.townyflight.util.Message;
 import com.gmail.llmdlio.townyflight.util.MetaData;
 import com.gmail.llmdlio.townyflight.util.Permission;
@@ -37,6 +38,10 @@ public class TempFlightTask implements Runnable {
 			if (!TownyAPI.getInstance().isTownyWorld(player.getWorld()))
 				continue;
 			if (Permission.has(player, "townyflight.bypass", true))
+				continue;
+			if (Settings.pauseTempFlightTimeWhileEssentialsAFK
+					&& Settings.essentialsFound
+					&& EssentialsIntegration.isAfk(player))
 				continue;
 			if (!player.getAllowFlight() || !player.isFlying())
 				continue;

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -4,7 +4,7 @@ main: com.gmail.llmdlio.townyflight.TownyFlight
 version: ${project.version}
 api-version: ${project.bukkitAPIVersion}
 depend: [Towny]
-softdepend: [SiegeWar]
+softdepend: [SiegeWar, Essentials]
 prefix: TownyFlight
 
 commands:


### PR DESCRIPTION
**Summary**
Adds an optional EssentialsX integration that pauses a player's flight time countdown while they are marked as AFK by EssentialsX.
The countdown automatically resumes when EssentialsX removes the player's AFK status, such as when they move/chat.

**Changes**
- Added EssentialsX as an optional dependency.
- Added the following configuration option, disabled by default:
```options: pause_tempflight_time_while_essentials_afk: false```
- Added an EssentialsX integration for checking a player's AFK status.
- Prevented temporary flight seconds from decreasing while:
  - the option is enabled, and;
  - EssentialsX is installed, and;
  - the player is marked as AFK by EssentialsX.
- Preserved existing behaviour (no countdown interruption) when EssentialsX is unavailable or the option is disabled.

**Testing**
- Confirmed EssentialsX dependency resolves successfully.
- Confirmed the staged changes contain no whitespace/other errors.
~~- A complete local Maven build could not be performed because the existing Towny Maven repo returned 502 while resolving Towny 0.102.0.0~~
- Successfully built TownyFlight with changes made. (senior citizen moment before)